### PR TITLE
readFileSync with utf-8 options

### DIFF
--- a/lib/tiapp.js
+++ b/lib/tiapp.js
@@ -23,7 +23,7 @@ var Tiapp = {
         this.isTitaniumProject = false;
         const file = new File(path);
         if (file.existsSync()) {
-            const fileData = fs.readFileSync(path, 'ascii');
+            const fileData = fs.readFileSync(path, 'utf-8');
             const parser = new xml2js.Parser();
             let json;
             parser.parseString(fileData.substring(0, fileData.length), function (err, result) {


### PR DESCRIPTION
tiapp.xml can have a 2bytes characters such as Korean.
So it should be read with utf-8 options.