### PR TITLE
Minor changes

### DIFF
--- a/lib/ui/toolbar.js
+++ b/lib/ui/toolbar.js
@@ -108,15 +108,15 @@ export default class Toolbar {
 			case 'ios':
 				buildOptions = [
 					<option value="run">Run</option>,
-					<option value="dist-adhoc">Ad-hoc</option>,
-					<option value="dist-appstore">Publish</option>,
+					<option value="dist-adhoc">Ad-Hoc</option>,
+					<option value="dist-appstore">App Store</option>,
 					<option value="custom">Custom</option>
 				];
 				break;
 			case 'android':
 				buildOptions = [
 					<option value="run">Run</option>,
-					<option value="dist-appstore">Publish</option>,
+					<option value="dist-appstore">Play Store</option>,
 					<option value="custom">Custom</option>
 				];
 				break;
@@ -374,7 +374,7 @@ export default class Toolbar {
 			}
 		}
 		this.targetOptions.push({ value: '', text: '', disabled: true });
-		this.targetOptions.push({ value: '', text: '──────────', disabled: true });
+		this.targetOptions.push({ value: '', text: '──────────────────', disabled: true });
 		this.targetOptions.push({ value: 'refresh', text: 'Refresh Targets' });
 
 		etch.update(this);
@@ -405,10 +405,13 @@ export default class Toolbar {
 					this.state.selectedTarget.android = emulator.id;
 				}
 			}
+			if (this.targets.emulators[type].length === 0) {
+				this.targetOptions.push({ value: '', text: `No ${type} Emulators`, disabled: true });
+			}
 		}
 
 		this.targetOptions.push({ value: '', text: '', disabled: true });
-		this.targetOptions.push({ value: '', text: '──────────', disabled: true });
+		this.targetOptions.push({ value: '', text: '──────────────────', disabled: true });
 		this.targetOptions.push({ value: 'refresh', text: 'Refresh Targets' });
 
 		etch.update(this);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "appcelerator-titanium",
   "main": "./lib/index",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Axway Appcelerator Titanium build tools and UI for Atom",
   "repository": "https://github.com/appcelerator/atom-appcelerator-titanium",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "appcelerator-titanium",
   "main": "./lib/index",
-  "version": "1.0.1",
+  "version": "1.0.0",
   "description": "Axway Appcelerator Titanium build tools and UI for Atom",
   "repository": "https://github.com/appcelerator/atom-appcelerator-titanium",
   "license": "Apache-2.0",


### PR DESCRIPTION
- [x] Rephrase adhoc/appstore. "Ad hoc" -> "Ad-Hoc", "Publish" -> "App Store" / "Play Store"
- [x] Show empty state if no Genymotion emulators available
- [x] Extend separator line between emulators and refresh button

For the last one, I did not test it on Windows, so hopefully the width of the menu is similar?