### PR TITLE
iOS provisioning profile fixes

### DIFF
--- a/lib/appc.js
+++ b/lib/appc.js
@@ -276,7 +276,9 @@ const Appc = {
 
 			for (const profile of deploymentProfiles) {
 				profile.disabled = false;
-				if (pem && profile.certs.indexOf(pem) === -1) {
+				if (profile.managed) {
+					profile.disabled = true;
+				} else if (pem && profile.certs.indexOf(pem) === -1) {
 					profile.disabled = true;
 				} else if (appId && !Utils.iOSProvisioinngProfileMatchesAppId(profile.appId, appId)) {
 					profile.disabled = true;

--- a/lib/providers/autoCompleteHelper.js
+++ b/lib/providers/autoCompleteHelper.js
@@ -59,6 +59,12 @@ export default {
 	 * @returns {Object}
 	 */
 	checkIsDeprecated(value) {
+		if (!value) {
+			return {
+				name: value,
+				deprecated: false
+			};
+		}
 		const valueArray = value.split('|');
 		const deprecated = (valueArray[1] === 'deprecated');
 		return {

--- a/lib/tiapp.js
+++ b/lib/tiapp.js
@@ -67,7 +67,7 @@ const Tiapp = {
 	 * @returns {String}
 	 */
 	appId: function () {
-		return this.tiapp.id;
+		return String(this.tiapp.id);
 	},
 
 	/**
@@ -76,7 +76,7 @@ const Tiapp = {
 	 * @returns {String}
 	 */
 	appName: function () {
-		return this.tiapp.name;
+		return String(this.tiapp.name);
 	},
 
 	/**

--- a/lib/ui/toolbar.js
+++ b/lib/ui/toolbar.js
@@ -483,7 +483,14 @@ export default class Toolbar {
 			}
 		}
 		this.iOSProvisioningProfiles.sort(function (a, b) {
-			return a.name > b.name;
+			var nameA = a.name.toLowerCase();
+			var nameB = b.name.toLowerCase();
+			if (nameA < nameB) {
+				return -1;
+			} else if (nameA > nameB) {
+				return 1;
+			}
+			return 0;
 		});
 	}
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -18,12 +18,12 @@ export default {
 	iOSProvisioinngProfileMatchesAppId(profileAppId, appId) {
 
 		// allow wildcard
-		if (profileAppId === '*') {
+		if (String(profileAppId) === '*') {
 			return true;
 		}
 
 		// allow explicit match
-		if (profileAppId === appId) {
+		if (String(profileAppId) === appId) {
 			return true;
 		}
 


### PR DESCRIPTION
[ATOM-30] Non-wildcard iOS provisioning profiles always shown as disabled
Marking managed provisioning profiles as invalid
Fixes provisioning profile ordering
[ATOM-28] Autocomplete error when creating styles for classes