### PR TITLE
Some bug-fixes and improvements

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -184,6 +184,8 @@ export default {
 		atom.menu.update();
 
 		Project.onModified(() => {
+			if (!this.toolbar) { return; }
+
 			this.toolbar.hud.display({
 				icon: Project.appIcon(),
 				text: Project.appName() + ' | ' + Project.sdk(),

--- a/lib/index.js
+++ b/lib/index.js
@@ -355,7 +355,7 @@ export default {
 			iOSCodeSigning,
 			androidKeystore,
 			customArgs,
-			disableLiveView
+			enableLiveview
 		} = this.toolbar.getState();
 		const logLevel = this.console.getLogLevel();
 		let message;
@@ -368,7 +368,7 @@ export default {
 				'--log-level', logLevel
 			];
 
-			if (!disableLiveView) {
+			if (enableLiveview) {
 				args.push('--liveview')
 			}
 
@@ -449,6 +449,19 @@ export default {
 
 		} else if (buildCommand === 'custom') {
 			args = customArgs.split(' ').concat([ '--project-dir', atom.project.getPaths()[0] ]);
+
+			// For custom args, check if the option was already appended previously and let the dev
+			// know that migration is recommended
+			if (enableLiveview) {
+				if (args.indexOf('--liveview') !== -1) {
+					atom.notifications.addError('Duplicate \'--liveview\' option', {
+						detail: `LiveView option \'--liveview\' already appended by custom arguments, but enabled via UI as well. Skipping duplicate argument ...`,
+						dismissable: true
+					});
+				} else {
+					args.push('--liveview')
+				}
+			}
 		}
 
 		const options = {

--- a/lib/index.js
+++ b/lib/index.js
@@ -354,7 +354,8 @@ export default {
 			targetType,
 			iOSCodeSigning,
 			androidKeystore,
-			customArgs
+			customArgs,
+			disableLiveView
 		} = this.toolbar.getState();
 		const logLevel = this.console.getLogLevel();
 		let message;
@@ -367,6 +368,10 @@ export default {
 				'--log-level', logLevel
 			];
 
+			if (!disableLiveView) {
+				args.push('--liveview')
+			}
+
 			const projectPath = (Project.isTitaniumApp) ? atom.project.getPaths()[0] : Project.pathForPlatform(platform);
 			args.push('--project-dir', projectPath);
 
@@ -375,7 +380,6 @@ export default {
 			}
 
 			if (targetType === 'device' && platform === 'ios') {
-
 				if (!iOSCodeSigning.certificate || !iOSCodeSigning.provisioningProfile) {
 					atom.notifications.addError('iOS code signing required', { detail: 'Please select a certificate and provisioning profile.' });
 					this.toolbar.expand();

--- a/lib/ui/button.js
+++ b/lib/ui/button.js
@@ -64,6 +64,9 @@ export default class Button {
 		if (this.opts.disabled) {
 			className += ' disabled';
 		}
+		if (this.opts.coDisabled) {
+			className += ' coDisabled';
+		}
 		return className;
 	}
 }

--- a/lib/ui/button.js
+++ b/lib/ui/button.js
@@ -12,11 +12,12 @@ export default class Button {
 	 * Constructor
 	 *
 	 * @param {Object}      opts 			arguments
-	 * @param {Boolean}     opts.flat		no border
 	 * @param {String}      opts.icon		icon class
 	 * @param {String}      opts.className	custom css class
+	 * @param {Boolean}     opts.flat		no border
 	 * @param {Boolean}     opts.custom		custom override
-	 * @param {Boolean}     opts.disabled	is disabled
+	 * @param {Boolean}     opts.disabled	is disabled, not clickable
+	 * @param {Boolean}     opts.grayed		is grayed out, but clickable
 	 * @param {Function}    opts.click		click event handler
 	 */
 	constructor(opts) {
@@ -64,8 +65,8 @@ export default class Button {
 		if (this.opts.disabled) {
 			className += ' disabled';
 		}
-		if (this.opts.coDisabled) {
-			className += ' coDisabled';
+		if (this.opts.grayed) {
+			className += ' grayed';
 		}
 		return className;
 	}

--- a/lib/ui/console.js
+++ b/lib/ui/console.js
@@ -101,7 +101,7 @@ export default class Console {
 	constructor(opts) {
 		this.state = {
 			isHidden: true,
-			logLevel: 'trace',
+			logLevel: 'info',
 			autoScroll: true,
 			showOnBuild: true
 		};
@@ -167,9 +167,9 @@ export default class Console {
 				<div class="toolbar-row">
 					<div className="toolbar-left">
 						<Select change={this.logLevelValueDidChange.bind(this)} value={this.state.logLevel}>
+							<option value="info">Info</option>
 							<option value="trace">Trace</option>
 							<option value="debug">Debug</option>
-							<option value="info">Info</option>
 							<option value="warn">Warn</option>
 							<option value="error">Error</option>
 						</Select>
@@ -263,8 +263,6 @@ export default class Console {
 			}
 			if (line.indexOf('[TRACE]') === 0 || line.indexOf('TRACE') !== -1) {
 				this.trace(line);
-			// } else if (line.indexOf('[INFO]') === 0 || line.indexOf('INFO') === 0) {
-			// 	this.info(line);
 			} else if (line.indexOf('[DEBUG]') === 0 || line.indexOf('DEBUG') !== -1) {
 				this.debug(line);
 			} else if (line.indexOf('[WARN]') === 0 || line.indexOf('WARN') !== -1) {

--- a/lib/ui/toolbar.js
+++ b/lib/ui/toolbar.js
@@ -163,7 +163,7 @@ export default class Toolbar {
 							<div className="toolbar-item-title icon icon-file" />
 							<Select ref="iOSProvisioningProfileSelect" attributes={{ style: 'width:200px;' }} value={this.state.iOSCodeSigning.provisioningProfile} change={this.iOSProvisioningProfileSelectValueDidChange.bind(this)}>
 								{this.iOSProvisioningProfiles.map(profile =>
-									<option value={profile.uuid} disabled={profile.disabled}>{profile.name}</option>
+									<option value={profile.uuid} disabled={profile.disabled || profile.expired}>{profile.name} ({profile.expired ? 'EXPIRED' : 'Expires: ' + new Date(profile.expirationDate).toLocaleDateString('en-US') } )</option>
 								)}
 							</Select>
 						</div>

--- a/lib/ui/toolbar.js
+++ b/lib/ui/toolbar.js
@@ -158,13 +158,13 @@ export default class Toolbar {
 							<div className="toolbar-item-title icon icon-organization" />
 							<Select ref="iOSCertificateSelect" attributes={{ style: 'width:200px;' }} value={this.state.iOSCodeSigning.certificate} change={this.iOSCertificateSelectValueDidChange.bind(this)}>
 								{this.iOSCertificates.map(certificate =>
-									<option value={certificate.name}>{certificate.name}</option>
+									<option value={certificate.name}>{certificate.name} ({certificate.expired ? 'EXPIRED' : 'Expires: ' + new Date(certificate.after).toLocaleDateString('en-US') })</option>
 								)}
 							</Select>
 							<div className="toolbar-item-title icon icon-file" />
 							<Select ref="iOSProvisioningProfileSelect" attributes={{ style: 'width:200px;' }} value={this.state.iOSCodeSigning.provisioningProfile} change={this.iOSProvisioningProfileSelectValueDidChange.bind(this)}>
 								{this.iOSProvisioningProfiles.map(profile =>
-									<option value={profile.uuid} disabled={profile.disabled || profile.expired}>{profile.name} ({profile.expired ? 'EXPIRED' : 'Expires: ' + new Date(profile.expirationDate).toLocaleDateString('en-US') } )</option>
+									<option value={profile.uuid} disabled={profile.disabled || profile.expired}>{profile.name} ({profile.expired ? 'EXPIRED' : 'Expires: ' + new Date(profile.expirationDate).toLocaleDateString('en-US') })</option>
 								)}
 							</Select>
 						</div>

--- a/lib/ui/toolbar.js
+++ b/lib/ui/toolbar.js
@@ -34,6 +34,7 @@ export default class Toolbar {
 			target: null,
 			targetName: null,
 			disableUI: true,
+			disableLiveView: true,
 			buildInProgress: false,
 			codeSigningAvailable: true,
 			showingCodeSigning: false,
@@ -237,6 +238,7 @@ export default class Toolbar {
 						</Select>
 
 						<Button icon="gear" flat="true" disabled={this.state.disableUI || !this.state.codeSigningAvailable} click={this.expandButtonClicked.bind(this)} />
+						<Button icon="eye" ref="liveViewDisabled" flat="true" coDisabled={this.state.disableLiveView} disabled={this.state.disableUI || this.state.buildCommand !== 'run'} click={this.liveViewButtonClicked.bind(this)} />
 					</div>
 
 					<Hud ref="hud" />
@@ -652,5 +654,15 @@ export default class Toolbar {
 	 */
 	toggleConsoleButtonClicked() {
 		atom.commands.dispatch(atom.views.getView(atom.workspace), 'appc:console:toggle');
+	}
+
+	/**
+	 * LiveView toggle button clicked
+	 */
+	liveViewButtonClicked() {
+		this.state.disableLiveView = !this.state.disableLiveView;
+
+		this.getState();
+		etch.update(this);
 	}
 }

--- a/lib/ui/toolbar.js
+++ b/lib/ui/toolbar.js
@@ -238,7 +238,7 @@ export default class Toolbar {
 						</Select>
 
 						<Button icon="gear" flat="true" disabled={this.state.disableUI || !this.state.codeSigningAvailable} click={this.expandButtonClicked.bind(this)} />
-						<Button icon="eye" ref="liveViewDisabled" flat="true" coDisabled={this.state.disableLiveView} disabled={this.state.disableUI || this.state.buildCommand !== 'run'} click={this.liveViewButtonClicked.bind(this)} />
+						<Button icon="eye" flat="true" coDisabled={this.state.disableLiveView} disabled={this.state.disableUI || this.state.buildCommand !== 'run'} click={this.liveViewButtonClicked.bind(this)} />
 					</div>
 
 					<Hud ref="hud" />
@@ -518,7 +518,8 @@ export default class Toolbar {
 	 * Build button clicked
 	 */
 	buildButtonClicked() {
-		atom.commands.dispatch(atom.views.getView(atom.workspace), (this.state.buildInProgress) ? 'appc:stop' : 'appc:build');
+		let command = (this.state.buildInProgress) ? 'appc:stop' : 'appc:build';
+		atom.commands.dispatch(atom.views.getView(atom.workspace), command);
 	}
 
 	/**

--- a/lib/ui/toolbar.js
+++ b/lib/ui/toolbar.js
@@ -39,7 +39,7 @@ export default class Toolbar {
 			codeSigningAvailable: true,
 			showingCodeSigning: false,
 			showingCustom: false,
-			customArgs: '',
+			customArgs: atom.config.get('appcelerator-titanium.general.customArgs') || '',
 			iOSCodeSigning: {
 				certificate: null,
 				provisioningProfile: null
@@ -201,8 +201,8 @@ export default class Toolbar {
 			expandedToolbarRow = (
 				<div className="toolbar-row">
 					<div className="toolbar-center">
-						<div className="toolbar-item-title">Custom args:</div>
-						<input className="input-text native-key-bindings input keystore-path-input" ref="customArgs" value={this.state.customArgs} attributes={{ placeholder: 'args passed to appc run command...' }} on={{ change: this.customArgsDidChange }} />
+						<div className="toolbar-item-title">Custom arguments:</div>
+						<input className="input-text native-key-bindings input keystore-path-input" ref="customArgs" value={this.state.customArgs} attributes={{ placeholder: 'Arguments passed to the "appc run" command ...' }} on={{ change: this.customArgsDidChange }} />
 					</div>
 					<div className="toolbar-right">
 						<Button flat="true" icon="x" click={this.expandButtonClicked.bind(this)} />
@@ -342,7 +342,7 @@ export default class Toolbar {
 			atom.config.set('appcelerator-titanium.android.keystoreAlias', this.state.androidKeystore.alias);
 		}
 
-		if (this.refs.customArgs) {
+		if (this.refs.customArgs && this.refs.customArgs.value.length > 0) {
 			this.state.customArgs = this.refs.customArgs.value;
 		}
 
@@ -639,6 +639,9 @@ export default class Toolbar {
 	 * Custom args changed
 	 */
 	customArgsDidChange() {
+		// Persist custom args for cross-launch usage
+		atom.config.set('appcelerator-titanium.general.customArgs', this.state.customArgs);
+
 		this.getState();
 		etch.update(this);
 	}

--- a/lib/ui/toolbar.js
+++ b/lib/ui/toolbar.js
@@ -34,7 +34,7 @@ export default class Toolbar {
 			target: null,
 			targetName: null,
 			disableUI: true,
-			disableLiveView: true,
+			enableLiveview: false,
 			buildInProgress: false,
 			codeSigningAvailable: true,
 			showingCodeSigning: false,
@@ -238,7 +238,7 @@ export default class Toolbar {
 						</Select>
 
 						<Button icon="gear" flat="true" disabled={this.state.disableUI || !this.state.codeSigningAvailable} click={this.expandButtonClicked.bind(this)} />
-						<Button icon="eye" flat="true" coDisabled={this.state.disableLiveView} disabled={this.state.disableUI || this.state.buildCommand !== 'run'} click={this.liveViewButtonClicked.bind(this)} />
+						<Button icon="eye" flat="true" grayed={!this.state.enableLiveview} disabled={this.shouldDisableLiveView()} click={this.liveViewButtonClicked.bind(this)} />
 					</div>
 
 					<Hud ref="hud" />
@@ -254,6 +254,14 @@ export default class Toolbar {
 
 			</div>
 		);
+	}
+
+	/**
+	 * Indicate if the LiveView button should be disabled.
+	 * @returns {Boolean} 
+	 */
+	shouldDisableLiveView() {
+		return this.state.disableUI || !(this.state.buildCommand === 'run' || this.state.buildCommand === 'custom');
 	}
 
 	/**
@@ -342,7 +350,7 @@ export default class Toolbar {
 			atom.config.set('appcelerator-titanium.android.keystoreAlias', this.state.androidKeystore.alias);
 		}
 
-		if (this.refs.customArgs && this.refs.customArgs.value.length > 0) {
+		if (this.refs.customArgs) {
 			this.state.customArgs = this.refs.customArgs.value;
 		}
 
@@ -640,7 +648,7 @@ export default class Toolbar {
 	 */
 	customArgsDidChange() {
 		// Persist custom args for cross-launch usage
-		atom.config.set('appcelerator-titanium.general.customArgs', this.state.customArgs);
+		atom.config.set('appcelerator-titanium.general.customArgs', this.state.customArgs || '');
 
 		this.getState();
 		etch.update(this);
@@ -664,7 +672,7 @@ export default class Toolbar {
 	 * LiveView toggle button clicked
 	 */
 	liveViewButtonClicked() {
-		this.state.disableLiveView = !this.state.disableLiveView;
+		this.state.enableLiveview = !this.state.enableLiveview;
 
 		this.getState();
 		etch.update(this);

--- a/styles/appc.less
+++ b/styles/appc.less
@@ -70,6 +70,10 @@
         min-width: 25px;
     }
 
+    .coDisabled {
+        color: darken(@text-color, 30%);
+    }
+
     .disabled {
         color: darken(@text-color, 30%);
     }

--- a/styles/appc.less
+++ b/styles/appc.less
@@ -70,11 +70,7 @@
         min-width: 25px;
     }
 
-    .coDisabled {
-        color: darken(@text-color, 30%);
-    }
-
-    .disabled {
+    .grayed, .disabled {
         color: darken(@text-color, 30%);
     }
 


### PR DESCRIPTION
- Fix #91: Add expiration date to certificates **and** provisioning profiles

<img width="600" alt="bildschirmfoto 2018-07-01 um 09 58 59" src="https://user-images.githubusercontent.com/10667698/42132642-4b2d47f8-7d1c-11e8-8f1d-1b64635f39c8.png">

- Fix #108: Add LiveView

<img width="440" alt="bildschirmfoto 2018-07-01 um 10 49 10" src="https://user-images.githubusercontent.com/10667698/42132647-66c9a614-7d1c-11e8-9522-37177f66dd77.png">

- Fix #103: Fix HUD-error
- Fix #90: Use `INFO` log-level by default, for parity with Studio
- Fix #114: Allow custom args to be saved across Atom sessions