### PR TITLE
Save environment across Atom launches

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -349,9 +349,11 @@ export default {
 			if (!this.console) {
 				this.console = new Console(this.serializedState.console);
 			}
+
 			atom.config.onDidChange('appcelerator-titanium.general.showToolbar', () => {
 				this.toolbar.toggle();
 			});
+
 			atom.config.onDidChange('appcelerator-titanium.general.useTi', async () => {
 				this.prepare();
 				setHud();
@@ -368,6 +370,7 @@ export default {
 					default: true
 				});
 			};
+
 			setHud();
 
 			await this.prepare();
@@ -709,6 +712,7 @@ export default {
 		this.runProc.kill();
 		this.toolbar.hud.displayDefault();
 		this.toolbar.update({ buildInProgress: false });
+
 		if (this.touchBar) {
 			this.touchBar.replaceItem({
 				label: 'build',
@@ -969,11 +973,7 @@ export default {
 
 		const setupTargets = () => {
 			autoCompleteHelper.generateAutoCompleteSuggestions();
-			if (os.platform() === 'darwin') {
-				this.toolbar.populateiOSTargets();
-			} else {
-				this.toolbar.populateAndroidTargets();
-			}
+			this.toolbar.refreshTargets();
 			this.toolbar.update({ disableUI: false });
 			this.toolbar.hud.displayDefault();
 			if (Utils.usingAppcTooling()) {

--- a/lib/project.js
+++ b/lib/project.js
@@ -161,7 +161,7 @@ const Project = {
 	},
 
 	/**
-	 * Returns app name
+	 * Returns the app name
 	 *
 	 * @returns {String}
 	 */
@@ -171,6 +171,20 @@ const Project = {
 		} else {
 			return this.modules[0].name;
 		}
+	},
+
+	/**
+	 * Returns normalized app name
+	 *
+	 * @returns {String}
+	 */
+	normalizedAppName() {
+		return this.appName().toString().toLowerCase()
+			.replace(/\s+/g, '-')           // Replace spaces with -
+			.replace(/[^\w-]+/g, '')       // Remove all non-word chars
+			.replace(/--+/g, '-')         // Replace multiple - with single -
+			.replace(/^-+/, '')             // Trim - from start of text
+			.replace(/-+$/, '');            // Trim - from end of text
 	},
 
 	/**

--- a/lib/ui/toolbar.jsx
+++ b/lib/ui/toolbar.jsx
@@ -675,8 +675,8 @@ export default class Toolbar {
 	/**
 	 * Android keystore button clicked
 	 */
-	androidKeystoreButtonClicked() {
-		const filePaths = remote.dialog.showOpenDialog({ properties: [ 'openFile', 'showHiddenFiles' ] });
+	async androidKeystoreButtonClicked() {
+		const { filePaths } = await remote.dialog.showOpenDialog({ properties: [ 'openFile', 'showHiddenFiles' ] });
 		if (filePaths && filePaths[0].length > 0) {
 			this.state.androidKeystore.path = filePaths[0];
 		}


### PR DESCRIPTION
- [x] Save build command (run/adhoc/dist/custom) (per project)
- [x] Save selected iOS certificate and provisioning profile (per project)
- [x] Save selected platform
- [x] Save liveview selection (globally)

The selected target (e.g. Simulator) could also be saved, but is a bit too complex right now, because it also related to the selected UUID's and profiles. Leaving that one open for now.