### PR TITLE
Support macOS Touch-Bar

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,11 +2,7 @@
 
 import { CompositeDisposable, Disposable } from 'atom';
 const { BrowserWindow, TouchBar } = require('remote');
-
-const {
-	TouchBarButton,
-	TouchBarGroup
-} = TouchBar;
+const { TouchBarButton, TouchBarGroup } = TouchBar;
 
 import { exec } from 'child_process';
 import os from 'os';

--- a/lib/index.js
+++ b/lib/index.js
@@ -482,7 +482,7 @@ export default {
 									label: 'All',
 									click: () => {
 										atom.commands.dispatch(atom.views.getView(atom.workspace), 'appc:open-or-close-related');
-										this.touchBar.removeItem('all');
+										addBackItems();
 									}
 								}),
 								place: 1
@@ -493,7 +493,8 @@ export default {
 									label: 'Controller',
 									click: () => {
 										atom.commands.dispatch(atom.views.getView(atom.workspace), 'appc:open-related-controller');
-										this.touchBar.removeItem('controller');
+										addBackItems();
+
 									}
 								}),
 								place: 1
@@ -504,7 +505,8 @@ export default {
 									label: 'Style',
 									click: () => {
 										atom.commands.dispatch(atom.views.getView(atom.workspace), 'appc:open-related-style');
-										this.touchBar.removeItem('style');
+										addBackItems();
+
 									}
 								}),
 								place: 2
@@ -512,10 +514,10 @@ export default {
 							{
 								label: 'view',
 								tbItem: new TouchBarButton({
-									label: 'Open View',
+									label: 'View',
 									click: () => {
 										atom.commands.dispatch(atom.views.getView(atom.workspace), 'appc:open-related-view');
-										this.touchBar.removeItem('view');
+										addBackItems();
 									}
 								}),
 								place: 3

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,8 +1,7 @@
 'use babel';
 
 import { CompositeDisposable, Disposable } from 'atom';
-const { BrowserWindow, TouchBar } = require('remote');
-const { TouchBarButton, TouchBarGroup } = TouchBar;
+import { BrowserWindow, TouchBar, nativeImage } from 'remote';
 
 import { exec } from 'child_process';
 import os from 'os';
@@ -25,6 +24,9 @@ import styleAutoCompleteProvider from './providers/styleAutoCompleteProvider';
 import definitionsProvider from './providers/definitionsProvider';
 import related from './related';
 import { environment } from 'titanium-editor-commons';
+import TouchBarManager from './touchBarManager';
+
+const { TouchBarButton, TouchBarLabel } = TouchBar;
 
 export default {
 
@@ -427,49 +429,119 @@ export default {
 	},
 
 	configureTouchBar() {
-		const touchBarItems = [
-			new TouchBarButton({
-				label: 'Build',
+		this.touchBar = new TouchBarManager();
+
+		this.touchBar.addItem({
+			label: 'build',
+			tbItem: new TouchBarButton({
+				icon: nativeImage.createFromNamedImage('NSTouchBarPlayTemplate', [ -1, 0, 1 ]),
 				click: () => {
 					atom.commands.dispatch(atom.views.getView(atom.workspace), 'appc:build');
 				}
 			}),
-			new TouchBarButton({
-				label: 'Clean',
+			place: 1
+		});
+
+		this.touchBar.addItem({
+			label: 'clean',
+			tbItem: new TouchBarButton({
+				icon: nativeImage.createFromNamedImage('NSTouchBarDeleteTemplate', [ -1, 0, 1 ]),
 				click: () => {
 					atom.commands.dispatch(atom.views.getView(atom.workspace), 'appc:clean');
 				}
-			})
-		];
+			}),
+			place: 2
+		});
 
 		if (Utils.isAlloyProject()) {
-			touchBarItems.push(new TouchBarGroup({
-				items: new TouchBar([
-					new TouchBarButton({
-						label: 'Open View',
-						click: () => {
-							atom.commands.dispatch(atom.views.getView(atom.workspace), 'appc:open-related-view');
+			this.touchBar.addItem({
+				tbItem: new TouchBarButton({
+					label: 'Open Related',
+					click: () => {
+						const existingItems = this.touchBar.items;
+						const addBackItems = () => {
+							this.touchBar.addItems(existingItems);
+						};
+						const editor = atom.workspace.getActiveTextEditor();
+						if (!editor || !editor.getPath()) {
+							const item = {
+								tbItem: new TouchBarLabel({
+									label: 'No related items to open',
+									textColor: '#ffc107'
+								})
+							};
+
+							setTimeout(addBackItems, 1500);
+							this.touchBar.addItems([ item ]);
+							return;
 						}
-					}),
-					new TouchBarButton({
-						label: 'Open Style',
-						click: () => {
-							atom.commands.dispatch(atom.views.getView(atom.workspace), 'appc:open-related-style');
+						const items = [
+							{
+								label: 'all',
+								tbItem: new TouchBarButton({
+									label: 'All',
+									click: () => {
+										atom.commands.dispatch(atom.views.getView(atom.workspace), 'appc:open-or-close-related');
+										this.touchBar.removeItem('all');
+									}
+								}),
+								place: 1
+							},
+							{
+								label: 'controller',
+								tbItem: new TouchBarButton({
+									label: 'Controller',
+									click: () => {
+										atom.commands.dispatch(atom.views.getView(atom.workspace), 'appc:open-related-controller');
+										this.touchBar.removeItem('controller');
+									}
+								}),
+								place: 1
+							},
+							{
+								label: 'style',
+								tbItem: new TouchBarButton({
+									label: 'Style',
+									click: () => {
+										atom.commands.dispatch(atom.views.getView(atom.workspace), 'appc:open-related-style');
+										this.touchBar.removeItem('style');
+									}
+								}),
+								place: 2
+							},
+							{
+								label: 'view',
+								tbItem: new TouchBarButton({
+									label: 'Open View',
+									click: () => {
+										atom.commands.dispatch(atom.views.getView(atom.workspace), 'appc:open-related-view');
+										this.touchBar.removeItem('view');
+									}
+								}),
+								place: 3
+							}
+						];
+						switch (path.extname(editor.getPath())) {
+							case '.js':
+								items.splice(1, 1);
+								break;
+							case '.tss':
+								items.splice(2, 1);
+								break;
+							case '.xml':
+								items.splice(3, 1);
+								break;
 						}
-					}),
-					new TouchBarButton({
-						label: 'Open Controller',
-						click: () => {
-							atom.commands.dispatch(atom.views.getView(atom.workspace), 'appc:open-related-controller');
-						}
-					})
-				])
-			}));
+						this.touchBar.addItems(items);
+						this.touchBar.setEscape(new TouchBarButton({
+							label: 'Back',
+							click: addBackItems
+						}));
+					}
+				}),
+				place: 3
+			});
 		}
-
-		const touchBar = new TouchBar(touchBarItems);
-
-		BrowserWindow.getFocusedWindow().setTouchBar(touchBar);
 	},
 
 	/**
@@ -636,6 +708,18 @@ export default {
 		}
 		this.runProc = Appc.run(options);
 		this.toolbar.update({ buildInProgress: true });
+		if (this.touchBar) {
+			this.touchBar.replaceItem({
+				label: 'stop',
+				tbItem: new TouchBarButton({
+					icon: nativeImage.createFromNamedImage('NSTouchBarRecordStopTemplate', [ -1, 0, 1 ]),
+					click: () => {
+						atom.commands.dispatch(atom.views.getView(atom.workspace), 'appc:stop');
+					}
+				}),
+				toReplace: 'build'
+			});
+		}
 	},
 
 	/**
@@ -648,6 +732,18 @@ export default {
 		this.runProc.kill();
 		this.toolbar.hud.displayDefault();
 		this.toolbar.update({ buildInProgress: false });
+		if (this.touchBar) {
+			this.touchBar.replaceItem({
+				label: 'build',
+				tbItem: new TouchBarButton({
+					icon: nativeImage.createFromNamedImage('NSTouchBarPlayTemplate', [ -1, 0, 1 ]),
+					click: () => {
+						atom.commands.dispatch(atom.views.getView(atom.workspace), 'appc:build');
+					}
+				}),
+				toReplace: 'stop'
+			});
+		}
 	},
 
 	/**

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,18 +1,11 @@
 'use babel';
 
 import { CompositeDisposable, Disposable } from 'atom';
-const {BrowserWindow, TouchBar } = require('remote');
+const { BrowserWindow, TouchBar } = require('remote');
 
 const {
 	TouchBarButton,
-	TouchBarColorPicker,
-	TouchBarGroup,
-	TouchBarLabel,
-	TouchBarPopover,
-	TouchBarScrubber,
-	TouchBarSegmentedControl,
-	TouchBarSlider,
-	TouchBarSpacer
+	TouchBarGroup
 } = TouchBar;
 
 import { exec } from 'child_process';
@@ -434,20 +427,47 @@ export default {
 	},
 
 	configureTouchBar() {
-		const touchBar = new TouchBar([
+		const touchBarItems = [
 			new TouchBarButton({
 				label: 'Build',
 				click: () => {
-					this.runBuildCommand();
+					atom.commands.dispatch(atom.views.getView(atom.workspace), 'appc:build');
 				}
 			}),
 			new TouchBarButton({
 				label: 'Clean',
 				click: () => {
-					this.runCleanCommand();
+					atom.commands.dispatch(atom.views.getView(atom.workspace), 'appc:clean');
 				}
 			})
-		]);
+		];
+
+		if (Utils.isAlloyProject()) {
+			touchBarItems.push(new TouchBarGroup({
+				items: new TouchBar([
+					new TouchBarButton({
+						label: 'Open View',
+						click: () => {
+							atom.commands.dispatch(atom.views.getView(atom.workspace), 'appc:open-related-view');
+						}
+					}),
+					new TouchBarButton({
+						label: 'Open Style',
+						click: () => {
+							atom.commands.dispatch(atom.views.getView(atom.workspace), 'appc:open-related-style');
+						}
+					}),
+					new TouchBarButton({
+						label: 'Open Controller',
+						click: () => {
+							atom.commands.dispatch(atom.views.getView(atom.workspace), 'appc:open-related-controller');
+						}
+					})
+				])
+			}));
+		}
+
+		const touchBar = new TouchBar(touchBarItems);
 
 		BrowserWindow.getFocusedWindow().setTouchBar(touchBar);
 	},

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,20 @@
 'use babel';
 
 import { CompositeDisposable, Disposable } from 'atom';
+const {BrowserWindow, TouchBar } = require('remote');
+
+const {
+	TouchBarButton,
+	TouchBarColorPicker,
+	TouchBarGroup,
+	TouchBarLabel,
+	TouchBarPopover,
+	TouchBarScrubber,
+	TouchBarSegmentedControl,
+	TouchBarSlider,
+	TouchBarSpacer
+} = TouchBar;
+
 import { exec } from 'child_process';
 import os from 'os';
 import path from 'path';
@@ -226,6 +240,7 @@ export default {
 		this.console && this.console.destroy();
 		this.disposable.dispose();
 		this.projectDisposable.dispose();
+		BrowserWindow.getFocusedWindow().setTouchBar(null);
 	},
 
 	/**
@@ -415,6 +430,26 @@ export default {
 		}
 
 		atom.menu.update();
+		this.configureTouchBar();
+	},
+
+	configureTouchBar() {
+		const touchBar = new TouchBar([
+			new TouchBarButton({
+				label: 'Build',
+				click: () => {
+					this.runBuildCommand();
+				}
+			}),
+			new TouchBarButton({
+				label: 'Clean',
+				click: () => {
+					this.runCleanCommand();
+				}
+			})
+		]);
+
+		BrowserWindow.getFocusedWindow().setTouchBar(touchBar);
 	},
 
 	/**

--- a/lib/index.js
+++ b/lib/index.js
@@ -229,7 +229,10 @@ export default {
 		this.console && this.console.destroy();
 		this.disposable.dispose();
 		this.projectDisposable.dispose();
-		BrowserWindow.getFocusedWindow().setTouchBar(null);
+
+		if (Project.isTitaniumApp) {
+			BrowserWindow.getFocusedWindow().setTouchBar(null);
+		}
 	},
 
 	/**
@@ -249,6 +252,8 @@ export default {
 	async loadProject() {
 		Project.load();
 		if (Project.isTitaniumApp || Project.isTitaniumModule) {
+			this.configureTouchBar();
+
 			this.projectDisposable.add(
 				atom.commands.add('atom-workspace', {
 					'appc:build': () => {
@@ -419,7 +424,6 @@ export default {
 		}
 
 		atom.menu.update();
-		this.configureTouchBar();
 	},
 
 	configureTouchBar() {

--- a/lib/touchBarManager.js
+++ b/lib/touchBarManager.js
@@ -1,0 +1,105 @@
+'use babel';
+
+import remote from 'remote';
+
+const { TouchBar } = remote;
+
+export default class TouchBarManager {
+
+	constructor() {
+		this.touchBar = new TouchBar([]);
+		this.items = [];
+		this.show();
+	}
+
+	/**
+	 * Clear all buttons from the TouchBar.
+	 *
+	 * @memberof TouchBarManager
+	 */
+	clear() {
+		this.items = [];
+		this.show();
+	}
+
+	/**
+	 * Add a single item to the TouchBar.
+	 *
+	 * @param {Object} item - Details for the item to be added to the TouchBar.
+	 * @param {String} item.label - Label to identify the item.
+	 * @param {Object} item.tbItem - Item to be added to the TouchBar.
+	 * @param {Number} [item.place=1] - Place for the item on the TouchBar, with 1 being leftmost item.
+	 * @param {Boolean} [item.show=true] - Layout the TouchBar once the item is added.
+	 * @memberof TouchBarManager
+	 */
+	addItem({ label, place = 1, show = true, tbItem } = {}) {
+		this.items.push({ label, place, tbItem });
+		this.items.sort((a, b) => a.place - b.place);
+		if (show) {
+			this.show();
+		}
+	}
+
+	/**
+	 * Clear the TouchBar, add multiple items, then show the items.
+	 *
+	 * @param {Array} items - Array of items to add.
+	 * @memberof TouchBarManager
+	 */
+	addItems(items) {
+		this.clear();
+		for (const item of items) {
+			this.addItem({ ...item, show: false });
+		}
+		this.show();
+	}
+
+	/**
+	 * Remove an item from the TouchBar
+	 *
+	 * @param {String} label - Label used to identify the item.
+	 * @memberof TouchBarManager
+	 */
+	removeItem(label) {
+		this.items = this.items.filter(existing => existing.label !== label);
+		this.show();
+	}
+
+	/**
+	 * Replace an item on the TouchBar.
+	 *
+	 * @param {Object} opts - Various options.
+	 * @param {String} opts.label - Label to identify the new item.
+	 * @param {Object} opts.tbItem - Item to add to TouchBar.
+	 * @param {String} opt.toReplace - Label to identify the item to replace.
+	 * @memberof TouchBarManager
+	 */
+	replaceItem({ label, tbItem, toReplace }) {
+		const item = this.items.find(item => item.label === toReplace);
+		if (!item) {
+			return;
+		}
+		this.removeItem(item.label);
+		this.addItem({ label, place: item.place, tbItem });
+	}
+
+	/**
+	 * Set the escape key.
+	 *
+	 * @param {Object} item - Item to set the escape key to.
+	 * @memberof TouchBarManager
+	 */
+	setEscape(item) {
+		this.touchBar.escapeItem = item;
+	}
+
+	/**
+	 * Show the buttons on the TouchBar.
+	 *
+	 * @memberof TouchBarManager
+	 */
+	show() {
+		this.touchBar = new TouchBar(this.items.map(i => i.tbItem));
+		remote.getCurrentWindow().setTouchBar(this.touchBar);
+	}
+}

--- a/lib/touchBarManager.js
+++ b/lib/touchBarManager.js
@@ -55,7 +55,7 @@ export default class TouchBarManager {
 	}
 
 	/**
-	 * Remove an item from the TouchBar
+	 * Remove an item from the TouchBar.
 	 *
 	 * @param {String} label - Label used to identify the item.
 	 * @memberof TouchBarManager


### PR DESCRIPTION
Triggered by [this tweet](https://twitter.com/YakupKalin/status/1033667394957455360) and currently untested because of missing touch-bar on this Mac. 

It does not error when opening Atom, so it might actually work. If so, we need to move this to the toolbar-code, where we have a callback when everything is loaded. we could then think of which commands make sense, like opening the controller/view/style? 