### PR TITLE
Fix error being thrown when tiapp is invalid

### DIFF
--- a/lib/project.js
+++ b/lib/project.js
@@ -39,30 +39,38 @@ const Project = {
 	/**
 	 * Load tiapp file
 	 *
+	 * @param {Function} cb - Callback to be invoked if the tiapp parsing was successful.
 	 */
-	loadTiappFile() {
+	loadTiappFile(cb) {
 		const filePath = path.join(atom.project.getPaths()[0], TIAPP_FILENAME);
 		this.isTitaniumApp = false;
 		if (Utils.fileExists(filePath)) {
 			const fileData = fs.readFileSync(filePath, 'utf-8');
 			const parser = new xml2js.Parser();
 			let json;
-			parser.parseString(fileData, (err, result) => {
-				if (!err) {
+			try {
+				parser.parseString(fileData, (err, result) => {
+					if (err) {
+						throw err;
+					}
 					json = result;
+				});
+				if (json && json['ti:app']) {
+					this.tiapp = json['ti:app'];
+					this.isTitaniumApp = true;
+					cb && cb();
 				}
-			});
-			if (json && json['ti:app']) {
-				this.tiapp = json['ti:app'];
-				this.isTitaniumApp = true;
+			} catch (error) {
+				atom.notifications.addError('Failed to parse tiapp.xml', { detail: 'Please ensure your tiapp.xml is valid.' });
 			}
 
 			if (!this.watcher) {
 				this.watcher = atom.project.onDidChangeFiles(events => {
 					for (const event of events) {
 						if (event.path === filePath && event.action === 'modified') {
-							this.loadTiappFile();
-							this.emitter.emit(EVENT_MODIFIED);
+							this.loadTiappFile(() => {
+								this.emitter.emit(EVENT_MODIFIED);
+							});
 						}
 					}
 				});


### PR DESCRIPTION
Always attach the watcher, only emit modified event if parsing was successful. 
Fixes #128

Tests

1. Make your tiapp invalid (like in the linked issue), save it. A workspace error should be shown, but not other errors.
2. Fix the tiapp and the plugin should still function
3. Open a project with an invalid tiapp, it should notify that the tiapp is invalid. The watcher should still function (you can check by fixing and then re-invalidating the tiapp.

There's still an issue around opening a project where the tiapp is invalid, the build bar functionality doesn't get set up once the tiapp is fixed