### PR TITLE
Check if SDK is installed before generating autocompletion file and allow a user to install an SDK if they dont have one.

### DIFF
--- a/lib/appc.js
+++ b/lib/appc.js
@@ -526,6 +526,23 @@ const Appc = {
 
 		return proc;
 	},
+	installSDK(opts) {
+		const proc = new BufferedProcess({
+			command: atom.config.get('appcelerator-titanium.general.appcCommandPath'),
+			options: {
+				cwd: atom.project.getPaths()[0]
+			},
+			args: [ 'ti', 'sdk', 'install', opts.version, '--default' ],
+			stdout: output => opts.log && opts.log(output),
+			stderr: output => opts.error && opts.error(output),
+			exit: code => opts.callback && opts.callback(code)
+		});
+		proc.onWillThrowError(error => {
+			this.showAppcCommandError('Error executing \'appc ti sdk install\' command');
+			error.handle();
+			opts.callback && opts.callback(1);
+		});
+	}
 };
 
 export default Appc;

--- a/lib/index.js
+++ b/lib/index.js
@@ -313,17 +313,48 @@ export default {
 				text: 'Preparing...',
 				spinner: true
 			});
+
+			const setupTargets = () => {
+				autoCompleteHelper.generateAutoCompleteSuggestions();
+				if (os.platform() === 'darwin') {
+					this.toolbar.populateiOSTargets();
+				} else {
+					this.toolbar.populateAndroidTargets();
+				}
+				this.toolbar.update({ disableUI: false });
+				this.toolbar.hud.displayDefault();
+			};
+
 			setTimeout(() => { // FIXME: Can we solve this without timeouts?
 				Appc.getInfo(() => {
-					autoCompleteHelper.generateAutoCompleteSuggestions();
-
-					if (os.platform() === 'darwin') {
-						this.toolbar.populateiOSTargets();
+					const sdk = Appc.selectedSdk();
+					if (!sdk) {
+						const errorNotification = atom.notifications.addError('No Titanium SDK installed. Would you like to install the latest?', {
+							buttons: [
+								{
+									onDidClick: () => {
+										errorNotification.dismiss();
+										Appc.installSDK({
+											version: 'latest',
+											callback: (code) => {
+												if (code) {
+													atom.notifications.addWarning('Unable to install SDK');
+													return;
+												}
+												atom.notifications.addSuccess('Installed SDK');
+												Appc.getInfo(() => {
+													setupTargets();
+												});
+											}
+										});
+									},
+									text: 'Install latest SDK'
+								}
+							]
+						});
 					} else {
-						this.toolbar.populateAndroidTargets();
+						setupTargets();
 					}
-					this.toolbar.update({ disableUI: false });
-					this.toolbar.hud.displayDefault();
 				});
 			}, 1000);
 		} else {

--- a/lib/index.js
+++ b/lib/index.js
@@ -350,7 +350,8 @@ export default {
 									},
 									text: 'Install latest SDK'
 								}
-							]
+							],
+							dismissable: true,
 						});
 					} else {
 						setupTargets();


### PR DESCRIPTION
Fixes #106

To test:

1. Remove/rename your sdk folder
2. Remove the completions file
3. Open a project. You should get an error that there's no SDK installed, with a button to install the latest SDK, once the SDK is installed a success message should pop up