### PR TITLE
fix(definitions): do not suggest app.tss when generating tss for id

### DIFF
--- a/lib/providers/definitionsProvider.js
+++ b/lib/providers/definitionsProvider.js
@@ -86,8 +86,7 @@ const suggestions = {
 			},
 			targetPath: function () {
 				return [
-					related.getTargetPath('tss'),
-					path.join(atom.project.getPaths()[0], 'app', 'styles', 'app.tss')
+					related.getTargetPath('tss')
 				];
 			}
 		},


### PR DESCRIPTION
While this works in alloy, we should try and guide people to not create tss rules by id in the app.tss

Closes #141


### Verification

1. Add an id in an xml tag
2. `cmd+click` the id name

It should only offer `Generate style <name of file>`