### PR TITLE
fix(autocomplete): correct filtering of colors

### DIFF
--- a/lib/providers/styleAutoCompleteProvider.js
+++ b/lib/providers/styleAutoCompleteProvider.js
@@ -255,7 +255,7 @@ export default {
 	},
 
 	getPropertyValueCompletions(request) {
-		const { bufferPosition, editor, prefix, scopeDescriptor } = request;
+		let { bufferPosition, editor, prefix, scopeDescriptor } = request;
 		const property = this.getPreviousPropertyName(bufferPosition, editor);
 		// const parentPropertyName = this.getParentObjectName(bufferPosition, editor);
 
@@ -273,17 +273,19 @@ export default {
 
 		const completions = [];
 		if (this.isPropertyValuePrefix(prefix)) {
-			for (const value of values) {
-				if (Utils.firstCharsEqual(value.replace(/"/g, ''), prefix.replace(/"/g, ''))) {
-					if (Utils.firstCharsEqual(value, prefix)) {
-						completions.push(this.buildPropertyValueCompletion(value, property, scopes, request));
-					} else {
-						// completions.push(this.buildPropertyValueCompletionWidthQuotation(value, property, scopes, request));
-					}
+			for (let value of values) {
+				if (/["']/.test(value)) {
+					value = value.replace(/["']/g, '');
+				}
+				if (Utils.firstCharsEqual(value, prefix)) {
+					completions.push(this.buildPropertyValueCompletion(value, property, scopes, request));
 				}
 			}
 		} else {
-			for (const value of values) {
+			for (let value of values) {
+				if (/["']/.test(value)) {
+					value = value.replace(/["']/g, '');
+				}
 				completions.push(this.buildPropertyValueCompletion(value, property, scopes, request));
 			}
 		}

--- a/spec/styleAutoCompleteProvider-spec.js
+++ b/spec/styleAutoCompleteProvider-spec.js
@@ -126,4 +126,13 @@ describe('Property suggestions', function () {
 
 		expect(suggestions.length).toBe(0);
 	});
+
+	it('should provide color values', function () {
+		Project.isTitaniumApp = true;
+		initTextEditor('"#id":{');
+		editor.insertNewline();
+		editor.insertText('color: "ma"');
+		const suggestions = getSuggestions('"ma"');
+		expect(suggestions.length).toBe(2);
+	});
 });


### PR DESCRIPTION
Fixes #139

### Verification

1. Setup a tss like the below
2. Type in `""` should get all suggested
3. Type in `"ma"` - should get magenta and maroon suggested
3. Type in `"mage"` - should get just magenta

```
"label": {
	color: 
}

```