### PR TITLE
fix(toolbar/android): handle emulators being undefined, improve ui wh…

### DIFF
--- a/lib/appc.js
+++ b/lib/appc.js
@@ -193,21 +193,20 @@ const Appc = {
 	 * @returns {Object}
 	 */
 	androidEmulators() {
-		if (Appc.info.android && Appc.info.android.emulators.length) {
-			var emulators = {
-				AVDs: [],
-				Genymotion: []
-			};
+		var emulators = {
+			AVD: [],
+			Genymotion: []
+		};
+		if (Appc.info.android && Appc.info.android.emulators && Appc.info.android.emulators.length) {
 			for (const emulator of Appc.info.android.emulators) {
 				if (emulator.type === 'avd') {
-					emulators.AVDs.push(emulator);
+					emulators.AVD.push(emulator);
 				} else if (emulator.type === 'genymotion') {
 					emulators.Genymotion.push(emulator);
 				}
 			}
-			return emulators;
 		}
-		return {};
+		return emulators;
 	},
 
 	/**

--- a/lib/ui/toolbar.jsx
+++ b/lib/ui/toolbar.jsx
@@ -427,10 +427,11 @@ export default class Toolbar {
 				this.targetOptions.push({ value: target.id, text: target.name });
 			}
 		}
-		for (const type in this.targets.emulators) {
+
+		for (const [ type, emulators ] of Object.entries(this.targets.emulators)) {
 			this.targetOptions.push({ value: '', text: ' ', disabled: true });
 			this.targetOptions.push({ value: '', text: type, disabled: true });
-			for (const emulator of this.targets.emulators[type]) {
+			for (const emulator of emulators) {
 				const emulatorSdkVersion = emulator['sdk-version'] || 'SDK not installed';
 				const name = `${emulator.name} (${emulatorSdkVersion})`;
 				this.targetOptions.push({ value: emulator.id, text: name });


### PR DESCRIPTION
Check that emulators exists before trying to access it, default to the emulators object so that toolbar dropdown shows that there are no emulators installed rather than just being blank

Fixes #142