### PR TITLE
ci: move travis to using xenial to fix extract issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ git:
 
 sudo: false
 
-dist: trusty
+dist: xenial
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,3 +43,4 @@ addons:
     - fakeroot
     - git
     - libsecret-1-dev
+    - libgconf-2-4


### PR DESCRIPTION
See https://github.com/atom/ci/issues/94 for more info

We've had a slew of builds fails recently due to failing to extract the beta channel package, it seems this works on xenial so lets use that