### PR TITLE
Add "open related..." to context menu

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -326,6 +326,16 @@ export default {
 						// 'appc:closeRelated': () => related.closeRelatedFiles({forceAllClose: true})
 					})
 				);
+
+				// add contect menu
+				atom.contextMenu.add({
+					'atom-workspace': [
+						{label: "Open related view", command:'appc:open-related-view', shouldDisplay: () => this.checkShouldDisplay("xml")},
+						{label: "Open related style", command:'appc:open-related-style', shouldDisplay: () => this.checkShouldDisplay("tss")},
+						{label: "Open related controller", command:'appc:open-related-controller', shouldDisplay: () => this.checkShouldDisplay("js")},
+						{label: "Open/Close all related", command:'appc:open-or-close-related', shouldDisplay: () => this.checkShouldDisplay("")}
+					]
+				});
 			} else {
 				keymap = require('./keymap/module');
 				menu = require('./menu/module');
@@ -975,6 +985,15 @@ export default {
 				updateInfo: details
 			});
 			return details;
+		}
+	},
+
+	checkShouldDisplay(type) {
+		const editor = atom.workspace.getActiveTextEditor();
+		if (editor && editor.getPath()) {
+			return path.parse(editor.getPath()).ext.substr(1) != type;
+		} else {
+			return false;
 		}
 	}
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -330,10 +330,10 @@ export default {
 				// add contect menu
 				atom.contextMenu.add({
 					'atom-workspace': [
-						{label: "Open related view", command:'appc:open-related-view', shouldDisplay: () => this.checkShouldDisplay("xml")},
-						{label: "Open related style", command:'appc:open-related-style', shouldDisplay: () => this.checkShouldDisplay("tss")},
-						{label: "Open related controller", command:'appc:open-related-controller', shouldDisplay: () => this.checkShouldDisplay("js")},
-						{label: "Open/Close all related", command:'appc:open-or-close-related', shouldDisplay: () => this.checkShouldDisplay("")}
+						{ label: 'Open related view', command: 'appc:open-related-view', shouldDisplay: () => this.checkShouldDisplay('xml') },
+						{ label: 'Open related style', command: 'appc:open-related-style', shouldDisplay: () => this.checkShouldDisplay('tss') },
+						{ label: 'Open related controller', command: 'appc:open-related-controller', shouldDisplay: () => this.checkShouldDisplay('js') },
+						{ label: 'Open/Close all related', command: 'appc:open-or-close-related', shouldDisplay: () => this.checkShouldDisplay('') }
 					]
 				});
 			} else {
@@ -991,7 +991,7 @@ export default {
 	checkShouldDisplay(type) {
 		const editor = atom.workspace.getActiveTextEditor();
 		if (editor && editor.getPath()) {
-			return path.parse(editor.getPath()).ext.substr(1) != type;
+			return path.parse(editor.getPath()).ext.substr(1) !== type;
 		} else {
 			return false;
 		}


### PR DESCRIPTION
Adding "Open related..." menu options to the context menu.
Current open tab will decide which options are visible.

Feature for: https://github.com/appcelerator/atom-appcelerator-titanium/issues/174

![Screenshot_20190810_130756](https://user-images.githubusercontent.com/4334997/62821135-1b48d500-bb70-11e9-99e5-92ceef993814.png)

