### PR TITLE
feat: change the console icon to command line icon

### DIFF
--- a/lib/ui/toolbar.jsx
+++ b/lib/ui/toolbar.jsx
@@ -268,7 +268,7 @@ export default class Toolbar {
 
 					<div className="toolbar-right main-toolbar-group">
 						<Button icon="plus" title="Create new..." className="button-right" flat="true" disabled={this.state.disableUI || !Project.isTitaniumApp} click={this.generateButtonClicked.bind(this)} />
-						<Button icon="three-bars" title="Toggle console" className="button-right" flat="true" disabled={this.state.disableUI} click={this.toggleConsoleButtonClicked.bind(this)} />
+						<Button icon="terminal" title="Toggle console" className="button-right" flat="true" disabled={this.state.disableUI} click={this.toggleConsoleButtonClicked.bind(this)} />
 						<Button ref="loginDetails" icon={userButtonIcon} title={this.loginDetails} className="button-right" flat="true" disabled={this.state.disableUI} click={this.userProfile.bind(this)} />
 						<Button icon="x" title="Hide Toolbar" className="button-right" flat="true" click={this.toggle.bind(this)} />
 					</div>


### PR DESCRIPTION
The three-bars icon (hamburger menu) is typically for an additional options menu. The terminal icon is more suitable for toggling the console.  