### PR TITLE
feat(ios): support generic apple certificates

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,6 +12,11 @@
 		"react/jsx-no-bind": "off", 
 		"react/no-string-refs": "off",
 		"no-control-regex": "off",
-		"jsx-a11y/label-has-for": "off"
+		"jsx-a11y/label-has-for": "off",
+		"node/no-unsupported-features/es-syntax": ["warn", {
+			"ignores": [
+				"modules"
+			]
+		}]
 	}
 }

--- a/lib/appc.js
+++ b/lib/appc.js
@@ -334,7 +334,9 @@ const Appc = {
 				} else if (appId && !Utils.iOSProvisioningProfileMatchesAppId(profile.appId, appId)) {
 					profile.disabled = true;
 				}
-				profiles.push(profile);
+				if (!profile.disabled) {
+					profiles.push(profile);
+				}
 			}
 		}
 		return profiles;

--- a/lib/index.js
+++ b/lib/index.js
@@ -602,23 +602,24 @@ export default {
 			}
 
 			if (targetType === 'device' && platform === 'ios') {
-				if (!iOSCodeSigning.certificate || !iOSCodeSigning.provisioningProfile) {
+				const certificateName = Utils.getCorrectCertificateName(iOSCodeSigning.certificate, Project.sdk()[0], 'developer');
+				if (!certificateName || !iOSCodeSigning.provisioningProfile) {
 					atom.notifications.addError('iOS code signing required', { detail: 'Please select a certificate and provisioning profile.' });
 					this.toolbar.expand();
 					return;
 				}
 
-				args = args.concat([
-					'--developer-name', iOSCodeSigning.certificate,
+				args.push(
+					'--developer-name', certificateName,
 					'--pp-uuid', iOSCodeSigning.provisioningProfile
-				]);
+				);
 			}
 
 			message = `${platformName} ${targetType} ${targetName}`;
 
 		} else if (buildCommand === 'dist-adhoc' || buildCommand === 'dist-appstore' && platform === 'ios') {
-
-			if (!iOSCodeSigning.certificate || !iOSCodeSigning.provisioningProfile || iOSCodeSigning.provisioningProfile === '-') {
+			const certificateName = Utils.getCorrectCertificateName(iOSCodeSigning.certificate, Project.sdk()[0], 'distribution');
+			if (!certificateName || !iOSCodeSigning.provisioningProfile || iOSCodeSigning.provisioningProfile === '-') {
 				atom.notifications.addError('iOS code signing required', { detail: 'Please select a certificate and provisioning profile.' });
 				this.toolbar.expand();
 				return;
@@ -628,7 +629,7 @@ export default {
 				'--platform', platform,
 				'--project-dir', atom.project.getPaths()[0],
 				'--target', buildCommand,
-				'--distribution-name', iOSCodeSigning.certificate,
+				'--distribution-name', certificateName,
 				'--pp-uuid', iOSCodeSigning.provisioningProfile,
 				'--output-dir', Utils.distributionOutputDirectory(),
 				'--log-level', logLevel

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,7 +1,9 @@
 'use babel';
 
+import Appc from './appc';
 import fs from 'fs';
 import path from 'path';
+import semver from 'semver';
 import _ from 'underscore';
 import { TextBuffer } from 'atom';
 import { platform } from 'os';
@@ -273,4 +275,28 @@ export default {
 
 		return args;
 	},
+
+	/**
+	 * Determine the correct certificate name value to provide to the SDK build process.
+	 * Prior to SDK 8.2.0 only the "name" property was allowed, but for 8.2.0 and above
+	 * we should prefer the fullname as it differentiates between the iPhone certs and
+	 * the generic Apple certs.
+	 *
+	 * @param {String} certificateName - Certificate fullname.
+	 * @param {String} sdkVersion - Projects SDK version in the tiapp.xml.
+	 * @param {String} certificateType - Type of certificate type to look up, developer or distribution.
+	 *
+	 * @returns {String}
+	 */
+	getCorrectCertificateName (certificateName, sdkVersion, certificateType) {
+		const certificate = Appc.iosCertificates(certificateType).find(certificate => certificate.fullname === certificateName);
+		if (!certificate) {
+			return;
+		}
+		if (semver.gte(semver.coerce(sdkVersion), '8.2.0')) {
+			return certificate.fullname;
+		} else {
+			return certificate.name;
+		}
+	}
 };

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "husky": "^2.5.0",
     "lint-staged": "^8.2.1",
     "mocha-jenkins-reporter": "^0.4.1",
-    "semver": "^6.1.2",
+    "semver": "^6.3.0",
     "standard-version": "^6.0.1"
   },
   "scripts": {

--- a/spec/appc-spec.js
+++ b/spec/appc-spec.js
@@ -67,35 +67,23 @@ describe('iOS provisioning profiles', function () {
 		it('should match certificate', function () {
 			const certificate = Appc.iosCertificates()[0];
 			const profiles = Appc.iosProvisioningProfiles('development', certificate);
-			expect(profiles.length).to.equal(3);
-			const enabledProfiles = profiles.filter((profile) => {
-				return !profile.disabled;
-			});
-			expect(enabledProfiles.length).to.equal(1);
-			expect(enabledProfiles[0].name).to.equal('Appcelerator Development Profile');
-			expect(enabledProfiles[0].team[0]).to.equal('WOUS58744L');
+			expect(profiles.length).to.equal(1);
+			expect(profiles[0].name).to.equal('Appcelerator Development Profile');
+			expect(profiles[0].team[0]).to.equal('WOUS58744L');
 		});
 
 		it('should match certificate and app ID', function () {
 			const certificate = Appc.iosCertificates()[0];
 			const profiles = Appc.iosProvisioningProfiles('development', certificate, 'com.appcelerator.test');
-			expect(profiles.length).to.equal(3);
-			const enabledProfiles = profiles.filter((profile) => {
-				return !profile.disabled;
-			});
-			expect(enabledProfiles.length).to.equal(1);
-			expect(enabledProfiles[0].name).to.equal('Appcelerator Development Profile');
-			expect(enabledProfiles[0].team[0]).to.equal('WOUS58744L');
+			expect(profiles.length).to.equal(1);
+			expect(profiles[0].name).to.equal('Appcelerator Development Profile');
+			expect(profiles[0].team[0]).to.equal('WOUS58744L');
 		});
 
 		it('should match certificate and not app ID', function () {
 			const certificate = Appc.iosCertificates()[0];
 			const profiles = Appc.iosProvisioningProfiles('development', certificate, 'com.axway.test');
-			expect(profiles.length).to.equal(3);
-			const enabledProfiles = profiles.filter((profile) => {
-				return !profile.disabled;
-			});
-			expect(enabledProfiles.length).to.equal(0);
+			expect(profiles.length).to.equal(0);
 		});
 
 	});

--- a/spec/utils-spec.js
+++ b/spec/utils-spec.js
@@ -2,7 +2,11 @@
 
 /* eslint-env mocha */
 
+import Appc from '../lib/appc';
 import Utils from '../lib/utils';
+import info from './data/ti_info';
+
+Appc.info = info;
 
 describe('iOS provisioning profile matches app ID', function () {
 
@@ -38,5 +42,18 @@ describe('iOS provisioning profile matches app ID', function () {
 			expect(Utils.iOSProvisioningProfileMatchesAppId('com.example.*', 'com.example.example.app')).to.be.ok;
 		});
 	});
+});
 
+describe('#getCorrectCertificateName', function () {
+
+	it('Should return correct name property for <8.2.0', function () {
+		const certificate = Utils.getCorrectCertificateName('iPhone Developer: Mrs Developer (D4BDS41234)', '8.1.1.GA', 'developer');
+		expect(certificate).to.equal('Mrs Developer (D4BDS41234)');
+
+	});
+
+	it('Should return correct name property for >=8.2.0', function () {
+		const certificate = Utils.getCorrectCertificateName('iPhone Developer: Mrs Developer (D4BDS41234)', '8.2.0.GA', 'developer');
+		expect(certificate).to.equal('iPhone Developer: Mrs Developer (D4BDS41234)');
+	});
 });


### PR DESCRIPTION
Prefer the fullname property of a certificate when displaying in the UI, as the name can be matching between the two this makes it easier to tell which is which, only show valid provisioning profiles, handle passing the correct certificate name to the SDK dependent on the projects version in the tiapp

Closes #183, kind of