### PR TITLE
fix(providers/tiapp): handle an open xml file that isn't on disk

### DIFF
--- a/lib/providers/tiappAutoCompleteProvider.js
+++ b/lib/providers/tiappAutoCompleteProvider.js
@@ -25,7 +25,10 @@ export default {
 			return;
 		}
 		const { editor, bufferPosition } = request;
-		if (!request.editor.getPath().endsWith('tiapp.xml')) {
+
+		const filePath = editor.getPath();
+
+		if (!filePath || !filePath.endsWith('tiapp.xml')) {
 			return;
 		}
 


### PR DESCRIPTION
getPath returns undefined if the file is yet to be saved

Fixes #284