### PR TITLE
feat(update): add node update and install functionality

### DIFF
--- a/lib/update.js
+++ b/lib/update.js
@@ -1,6 +1,9 @@
 'use babel';
 
 import { updates } from 'titanium-editor-commons';
+import Utils from './utils';
+import Project from './project';
+
 import sudo from 'sudo-prompt';
 
 const Update = {
@@ -11,7 +14,8 @@ const Update = {
 		this.checkingForUpdates = true;
 
 		try {
-			this.updates = await updates.checkAllUpdates();
+			const supportedVersions = await Utils.getNodeSupportedVersion(Project.sdk()[0]);
+			this.updates = await updates.checkAllUpdates({ nodeJS: supportedVersions });
 		} catch (error) {
 			// console.log(error);
 		}
@@ -45,7 +49,7 @@ const Update = {
 					});
 					if (error.metadata) {
 						const { metadata } = error;
-						if (update.productName === updates.ProductNames.AppcInstaller && metadata.errorCode === 'EACCES') {
+						if ((update.productName === updates.ProductNames.AppcInstaller || update.productName === updates.ProductNames.Node) && metadata.errorCode === 'EACCES') {
 							return new Promise((resolve, reject) => {
 								const errorNotification = atom.notifications.addError(`Failed to install ${label} as it must be ran with sudo`, {
 									dismissable: true,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,7 +1,7 @@
 'use babel';
 
 import Appc from './appc';
-import fs from 'fs';
+import fs from 'fs-extra';
 import path from 'path';
 import semver from 'semver';
 import _ from 'underscore';
@@ -298,5 +298,19 @@ export default {
 		} else {
 			return certificate.name;
 		}
+	},
+
+	async getNodeSupportedVersion(sdkVersion) {
+
+		const sdkInfo = Appc.sdkInfo(sdkVersion);
+		if (!sdkInfo) {
+			return;
+		}
+
+		const sdkPath = sdkInfo.path;
+
+		const packageJSON = path.join(sdkPath, 'package.json');
+		const { vendorDependencies } = await fs.readJSON(packageJSON);
+		return vendorDependencies.node;
 	}
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1607,131 +1607,6 @@
         "color-convert": "^1.9.0"
       }
     },
-    "appcd-dispatcher": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/appcd-dispatcher/-/appcd-dispatcher-2.0.3.tgz",
-      "integrity": "sha512-WmcHdKjIlLjhvjx1XDCQS6MEaQIeqYa3TAT5Tn0impvMaJXYZRwTsQuiB4bcjFpo/MYjL84R4a1plwn22B9kpg==",
-      "requires": {
-        "appcd-logger": "^2.0.5",
-        "appcd-response": "^2.0.3",
-        "gawk": "^4.7.0",
-        "path-to-regexp": "^6.1.0",
-        "pluralize": "^8.0.0",
-        "source-map-support": "^0.5.16",
-        "uuid": "^3.3.3"
-      },
-      "dependencies": {
-        "path-to-regexp": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.1.0.tgz",
-          "integrity": "sha512-h9DqehX3zZZDCEm+xbfU0ZmwCGFCAAraPJWMXJ4+v32NjZJilVg3k1TcKsRgIb8IQ/izZSaydDc1OhJCZvs2Dw=="
-        }
-      }
-    },
-    "appcd-fs": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/appcd-fs/-/appcd-fs-1.1.10.tgz",
-      "integrity": "sha512-hLtsgLpR5T5HacraXPCjtNP8yDc9sdGx6cLie0PoutwvhqVJcpkD1LXRLRweKBM/O/Nwwyb8Ry3Um/HxCtMN9g==",
-      "requires": {
-        "source-map-support": "^0.5.16"
-      }
-    },
-    "appcd-logger": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/appcd-logger/-/appcd-logger-2.0.5.tgz",
-      "integrity": "sha512-/YHgZEYBKijfp00TvpfCFmRMOqQ9NGRqJ3ydX513+3NztaNDpd5MPzKKwLnbAMEHTS+ttWEpCNpDMcWOyhRh6A==",
-      "requires": {
-        "snooplogg": "^2.3.3",
-        "source-map-support": "^0.5.16"
-      }
-    },
-    "appcd-nodejs": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/appcd-nodejs/-/appcd-nodejs-3.0.2.tgz",
-      "integrity": "sha512-zsT8vrjs+dS6/ch0zJarrSP5IOuTRcHoKaWbpHfpVfu0nCQqjjCHzfKEMjhnoJeekIJlU17o0mXrvRo82dQ9+g==",
-      "requires": {
-        "appcd-fs": "^1.1.10",
-        "appcd-logger": "^2.0.5",
-        "appcd-request": "^2.2.0",
-        "appcd-util": "^2.0.2",
-        "fs-extra": "^8.1.0",
-        "pluralize": "^8.0.0",
-        "progress": "^2.0.3",
-        "source-map-support": "^0.5.16",
-        "tar-stream": "^2.1.0",
-        "yauzl": "^2.10.0"
-      }
-    },
-    "appcd-path": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/appcd-path/-/appcd-path-1.1.10.tgz",
-      "integrity": "sha512-SHVMoAjhwJIYkqrP3P8JdKGNOOfK9TTsGnXHJ8/FprmvWEvv7p7NbUCPX6GcTahF46QrMIoAqEUeKzO744bd9Q==",
-      "requires": {
-        "source-map-support": "^0.5.16"
-      }
-    },
-    "appcd-request": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/appcd-request/-/appcd-request-2.2.0.tgz",
-      "integrity": "sha512-IdDl0TzR1h0sjBeEEUJ9RdOeYwcC09ydoU06IflqmvQkaGfB5lCM+GLJQLRFdXCwAYx/MjY1AK3M+DB5as6PHA==",
-      "requires": {
-        "appcd-dispatcher": "^2.0.3",
-        "appcd-fs": "^1.1.10",
-        "appcd-logger": "^2.0.5",
-        "humanize": "^0.0.9",
-        "request": "^2.88.0",
-        "source-map-support": "^0.5.16"
-      }
-    },
-    "appcd-response": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/appcd-response/-/appcd-response-2.0.4.tgz",
-      "integrity": "sha512-9QzB7XpqhuSUc8mToIl5zqgzFrfC87oX30smmhUDOlllFDuxOQmOKLWWHtfgDOLyoPNidHLIVhLxiQNklzKaoQ==",
-      "requires": {
-        "appcd-fs": "^1.1.10",
-        "appcd-path": "^1.1.9",
-        "source-map-support": "^0.5.16",
-        "sprintf-js": "^1.1.2"
-      }
-    },
-    "appcd-subprocess": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/appcd-subprocess/-/appcd-subprocess-3.0.2.tgz",
-      "integrity": "sha512-iABedfJHOlVXDWQGr1KnBV6HTKwj+440iZsVVXplLwIl/5rdm3e/wDyaBp2W7kVZLWvQbsLLUv+mg5eaGld+yA==",
-      "requires": {
-        "appcd-dispatcher": "^2.0.3",
-        "appcd-logger": "^2.0.5",
-        "appcd-nodejs": "^3.0.2",
-        "appcd-path": "^1.1.9",
-        "appcd-response": "^2.0.3",
-        "appcd-util": "^2.0.2",
-        "gawk": "^4.7.0",
-        "ps-tree": "^1.2.0",
-        "source-map-support": "^0.5.16",
-        "which": "^2.0.2"
-      },
-      "dependencies": {
-        "which": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-          "requires": {
-            "isexe": "^2.0.0"
-          }
-        }
-      }
-    },
-    "appcd-util": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/appcd-util/-/appcd-util-2.0.2.tgz",
-      "integrity": "sha512-57fIlDxdrENiist+uBv/1GsyQxC2vJhldxmXk5O+ue4WMtD8BdLDTmy4zX3aXtiFDGF4bTc4Hw1gEHauyWqHSA==",
-      "requires": {
-        "appcd-fs": "^1.1.10",
-        "lodash.get": "^4.4.2",
-        "semver": "^7.1.1",
-        "source-map-support": "^0.5.16"
-      }
-    },
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
@@ -2926,6 +2801,17 @@
             "lodash.map": "^4.5.1",
             "longest": "^2.0.1",
             "word-wrap": "^1.0.3"
+          }
+        },
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
           }
         },
         "minimist": {
@@ -5598,13 +5484,30 @@
       "dev": true
     },
     "fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
+      "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
       "requires": {
+        "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
+        "jsonfile": "^6.0.1",
+        "universalify": "^1.0.0"
+      },
+      "dependencies": {
+        "jsonfile": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
+          "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^1.0.0"
+          }
+        },
+        "universalify": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+          "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug=="
+        }
       }
     },
     "fs-minipass": {
@@ -11101,64 +11004,6 @@
         }
       }
     },
-    "snooplogg": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/snooplogg/-/snooplogg-2.3.3.tgz",
-      "integrity": "sha512-ibqjTxEjn4axSxl+bX17h71ioK/MN8xHdaLFNAkyqHvywOI5xqT7blyUm6ALPDYzfVNIe6Itr+61odaVSEU20A==",
-      "requires": {
-        "bryt": "^1.0.1",
-        "chalk": "^3.0.0",
-        "nanobuffer": "^1.1.6",
-        "source-map-support": "^0.5.16",
-        "supports-color": "^7.1.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-          "requires": {
-            "@types/color-name": "^1.1.1",
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
-    },
     "socks": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.3.3.tgz",
@@ -12182,18 +12027,169 @@
       "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
     },
     "titanium-editor-commons": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/titanium-editor-commons/-/titanium-editor-commons-0.5.1.tgz",
-      "integrity": "sha512-RPp8xKgWjv0DHkLOuaZUuTjZCqXFYhRbVoget8+0macNPQ4ND+BOqin4YZdNdj1M8FtRkZmXHbrwrhIza1LF3A==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/titanium-editor-commons/-/titanium-editor-commons-1.0.1.tgz",
+      "integrity": "sha512-/sqjX8IGckJBc0gtQCLhrl0sqA05KblPUIekkX/eNcUs386N/A4YNDTrKerAPFuzH9VpfZNrQxEgbanjGrs7gQ==",
       "requires": {
         "appcd-subprocess": "^3.0.1",
         "fs-extra": "^9.0.0",
         "got": "^9.6.0",
         "libnpm": "^3.0.1",
         "semver": "^7.1.3",
-        "titaniumlib": "^3.0.1"
+        "titaniumlib": "^3.0.0"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "appcd-dispatcher": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/appcd-dispatcher/-/appcd-dispatcher-2.0.3.tgz",
+          "integrity": "sha512-WmcHdKjIlLjhvjx1XDCQS6MEaQIeqYa3TAT5Tn0impvMaJXYZRwTsQuiB4bcjFpo/MYjL84R4a1plwn22B9kpg==",
+          "requires": {
+            "appcd-logger": "^2.0.5",
+            "appcd-response": "^2.0.3",
+            "gawk": "^4.7.0",
+            "path-to-regexp": "^6.1.0",
+            "pluralize": "^8.0.0",
+            "source-map-support": "^0.5.16",
+            "uuid": "^3.3.3"
+          }
+        },
+        "appcd-fs": {
+          "version": "1.1.10",
+          "resolved": "https://registry.npmjs.org/appcd-fs/-/appcd-fs-1.1.10.tgz",
+          "integrity": "sha512-hLtsgLpR5T5HacraXPCjtNP8yDc9sdGx6cLie0PoutwvhqVJcpkD1LXRLRweKBM/O/Nwwyb8Ry3Um/HxCtMN9g==",
+          "requires": {
+            "source-map-support": "^0.5.16"
+          }
+        },
+        "appcd-logger": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/appcd-logger/-/appcd-logger-2.0.5.tgz",
+          "integrity": "sha512-/YHgZEYBKijfp00TvpfCFmRMOqQ9NGRqJ3ydX513+3NztaNDpd5MPzKKwLnbAMEHTS+ttWEpCNpDMcWOyhRh6A==",
+          "requires": {
+            "snooplogg": "^2.3.3",
+            "source-map-support": "^0.5.16"
+          }
+        },
+        "appcd-nodejs": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/appcd-nodejs/-/appcd-nodejs-3.0.2.tgz",
+          "integrity": "sha512-zsT8vrjs+dS6/ch0zJarrSP5IOuTRcHoKaWbpHfpVfu0nCQqjjCHzfKEMjhnoJeekIJlU17o0mXrvRo82dQ9+g==",
+          "requires": {
+            "appcd-fs": "^1.1.10",
+            "appcd-logger": "^2.0.5",
+            "appcd-request": "^2.2.0",
+            "appcd-util": "^2.0.2",
+            "fs-extra": "^8.1.0",
+            "pluralize": "^8.0.0",
+            "progress": "^2.0.3",
+            "source-map-support": "^0.5.16",
+            "tar-stream": "^2.1.0",
+            "yauzl": "^2.10.0"
+          },
+          "dependencies": {
+            "fs-extra": {
+              "version": "8.1.0",
+              "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+              "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+              "requires": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
+              }
+            }
+          }
+        },
+        "appcd-path": {
+          "version": "1.1.10",
+          "resolved": "https://registry.npmjs.org/appcd-path/-/appcd-path-1.1.10.tgz",
+          "integrity": "sha512-SHVMoAjhwJIYkqrP3P8JdKGNOOfK9TTsGnXHJ8/FprmvWEvv7p7NbUCPX6GcTahF46QrMIoAqEUeKzO744bd9Q==",
+          "requires": {
+            "source-map-support": "^0.5.16"
+          }
+        },
+        "appcd-request": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/appcd-request/-/appcd-request-2.2.0.tgz",
+          "integrity": "sha512-IdDl0TzR1h0sjBeEEUJ9RdOeYwcC09ydoU06IflqmvQkaGfB5lCM+GLJQLRFdXCwAYx/MjY1AK3M+DB5as6PHA==",
+          "requires": {
+            "appcd-dispatcher": "^2.0.3",
+            "appcd-fs": "^1.1.10",
+            "appcd-logger": "^2.0.5",
+            "humanize": "^0.0.9",
+            "request": "^2.88.0",
+            "source-map-support": "^0.5.16"
+          }
+        },
+        "appcd-response": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/appcd-response/-/appcd-response-2.0.4.tgz",
+          "integrity": "sha512-9QzB7XpqhuSUc8mToIl5zqgzFrfC87oX30smmhUDOlllFDuxOQmOKLWWHtfgDOLyoPNidHLIVhLxiQNklzKaoQ==",
+          "requires": {
+            "appcd-fs": "^1.1.10",
+            "appcd-path": "^1.1.9",
+            "source-map-support": "^0.5.16",
+            "sprintf-js": "^1.1.2"
+          }
+        },
+        "appcd-subprocess": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/appcd-subprocess/-/appcd-subprocess-3.0.2.tgz",
+          "integrity": "sha512-iABedfJHOlVXDWQGr1KnBV6HTKwj+440iZsVVXplLwIl/5rdm3e/wDyaBp2W7kVZLWvQbsLLUv+mg5eaGld+yA==",
+          "requires": {
+            "appcd-dispatcher": "^2.0.3",
+            "appcd-logger": "^2.0.5",
+            "appcd-nodejs": "^3.0.2",
+            "appcd-path": "^1.1.9",
+            "appcd-response": "^2.0.3",
+            "appcd-util": "^2.0.2",
+            "gawk": "^4.7.0",
+            "ps-tree": "^1.2.0",
+            "source-map-support": "^0.5.16",
+            "which": "^2.0.2"
+          }
+        },
+        "appcd-util": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/appcd-util/-/appcd-util-2.0.2.tgz",
+          "integrity": "sha512-57fIlDxdrENiist+uBv/1GsyQxC2vJhldxmXk5O+ue4WMtD8BdLDTmy4zX3aXtiFDGF4bTc4Hw1gEHauyWqHSA==",
+          "requires": {
+            "appcd-fs": "^1.1.10",
+            "lodash.get": "^4.4.2",
+            "semver": "^7.1.1",
+            "source-map-support": "^0.5.16"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
         "fs-extra": {
           "version": "9.0.1",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
@@ -12203,21 +12199,61 @@
             "graceful-fs": "^4.2.0",
             "jsonfile": "^6.0.1",
             "universalify": "^1.0.0"
+          },
+          "dependencies": {
+            "jsonfile": {
+              "version": "6.0.1",
+              "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
+              "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+              "requires": {
+                "graceful-fs": "^4.1.6",
+                "universalify": "^1.0.0"
+              }
+            },
+            "universalify": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+              "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug=="
+            }
           }
         },
-        "jsonfile": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
-          "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "path-to-regexp": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.0.tgz",
+          "integrity": "sha512-f66KywYG6+43afgE/8j/GoiNyygk/bnoCbps++3ErRKsIYkGGupyv07R2Ok5m9i67Iqc+T2g1eAUGUPzWhYTyg=="
+        },
+        "snooplogg": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/snooplogg/-/snooplogg-2.3.3.tgz",
+          "integrity": "sha512-ibqjTxEjn4axSxl+bX17h71ioK/MN8xHdaLFNAkyqHvywOI5xqT7blyUm6ALPDYzfVNIe6Itr+61odaVSEU20A==",
           "requires": {
-            "graceful-fs": "^4.1.6",
-            "universalify": "^1.0.0"
+            "bryt": "^1.0.1",
+            "chalk": "^3.0.0",
+            "nanobuffer": "^1.1.6",
+            "source-map-support": "^0.5.16",
+            "supports-color": "^7.1.0"
           }
         },
-        "universalify": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-          "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug=="
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "requires": {
+            "isexe": "^2.0.0"
+          }
         }
       }
     },
@@ -12239,6 +12275,79 @@
         "yauzl": "^2.10.0"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "appcd-fs": {
+          "version": "1.1.10",
+          "resolved": "https://registry.npmjs.org/appcd-fs/-/appcd-fs-1.1.10.tgz",
+          "integrity": "sha512-hLtsgLpR5T5HacraXPCjtNP8yDc9sdGx6cLie0PoutwvhqVJcpkD1LXRLRweKBM/O/Nwwyb8Ry3Um/HxCtMN9g==",
+          "requires": {
+            "source-map-support": "^0.5.16"
+          }
+        },
+        "appcd-path": {
+          "version": "1.1.10",
+          "resolved": "https://registry.npmjs.org/appcd-path/-/appcd-path-1.1.10.tgz",
+          "integrity": "sha512-SHVMoAjhwJIYkqrP3P8JdKGNOOfK9TTsGnXHJ8/FprmvWEvv7p7NbUCPX6GcTahF46QrMIoAqEUeKzO744bd9Q==",
+          "requires": {
+            "source-map-support": "^0.5.16"
+          }
+        },
+        "appcd-util": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/appcd-util/-/appcd-util-2.0.2.tgz",
+          "integrity": "sha512-57fIlDxdrENiist+uBv/1GsyQxC2vJhldxmXk5O+ue4WMtD8BdLDTmy4zX3aXtiFDGF4bTc4Hw1gEHauyWqHSA==",
+          "requires": {
+            "appcd-fs": "^1.1.10",
+            "lodash.get": "^4.4.2",
+            "semver": "^7.1.1",
+            "source-map-support": "^0.5.16"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
         "request": {
           "version": "2.88.2",
           "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
@@ -12264,6 +12373,26 @@
             "tough-cookie": "~2.5.0",
             "tunnel-agent": "^0.6.0",
             "uuid": "^3.3.2"
+          }
+        },
+        "snooplogg": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/snooplogg/-/snooplogg-2.3.3.tgz",
+          "integrity": "sha512-ibqjTxEjn4axSxl+bX17h71ioK/MN8xHdaLFNAkyqHvywOI5xqT7blyUm6ALPDYzfVNIe6Itr+61odaVSEU20A==",
+          "requires": {
+            "bryt": "^1.0.1",
+            "chalk": "^3.0.0",
+            "nanobuffer": "^1.1.6",
+            "source-map-support": "^0.5.16",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
           }
         },
         "tough-cookie": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1607,6 +1607,143 @@
         "color-convert": "^1.9.0"
       }
     },
+    "appcd-dispatcher": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/appcd-dispatcher/-/appcd-dispatcher-2.0.3.tgz",
+      "integrity": "sha512-WmcHdKjIlLjhvjx1XDCQS6MEaQIeqYa3TAT5Tn0impvMaJXYZRwTsQuiB4bcjFpo/MYjL84R4a1plwn22B9kpg==",
+      "requires": {
+        "appcd-logger": "^2.0.5",
+        "appcd-response": "^2.0.3",
+        "gawk": "^4.7.0",
+        "path-to-regexp": "^6.1.0",
+        "pluralize": "^8.0.0",
+        "source-map-support": "^0.5.16",
+        "uuid": "^3.3.3"
+      },
+      "dependencies": {
+        "path-to-regexp": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.0.tgz",
+          "integrity": "sha512-f66KywYG6+43afgE/8j/GoiNyygk/bnoCbps++3ErRKsIYkGGupyv07R2Ok5m9i67Iqc+T2g1eAUGUPzWhYTyg=="
+        }
+      }
+    },
+    "appcd-fs": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/appcd-fs/-/appcd-fs-1.1.10.tgz",
+      "integrity": "sha512-hLtsgLpR5T5HacraXPCjtNP8yDc9sdGx6cLie0PoutwvhqVJcpkD1LXRLRweKBM/O/Nwwyb8Ry3Um/HxCtMN9g==",
+      "requires": {
+        "source-map-support": "^0.5.16"
+      }
+    },
+    "appcd-logger": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/appcd-logger/-/appcd-logger-2.0.5.tgz",
+      "integrity": "sha512-/YHgZEYBKijfp00TvpfCFmRMOqQ9NGRqJ3ydX513+3NztaNDpd5MPzKKwLnbAMEHTS+ttWEpCNpDMcWOyhRh6A==",
+      "requires": {
+        "snooplogg": "^2.3.3",
+        "source-map-support": "^0.5.16"
+      }
+    },
+    "appcd-nodejs": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/appcd-nodejs/-/appcd-nodejs-3.0.2.tgz",
+      "integrity": "sha512-zsT8vrjs+dS6/ch0zJarrSP5IOuTRcHoKaWbpHfpVfu0nCQqjjCHzfKEMjhnoJeekIJlU17o0mXrvRo82dQ9+g==",
+      "requires": {
+        "appcd-fs": "^1.1.10",
+        "appcd-logger": "^2.0.5",
+        "appcd-request": "^2.2.0",
+        "appcd-util": "^2.0.2",
+        "fs-extra": "^8.1.0",
+        "pluralize": "^8.0.0",
+        "progress": "^2.0.3",
+        "source-map-support": "^0.5.16",
+        "tar-stream": "^2.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        }
+      }
+    },
+    "appcd-path": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/appcd-path/-/appcd-path-1.1.10.tgz",
+      "integrity": "sha512-SHVMoAjhwJIYkqrP3P8JdKGNOOfK9TTsGnXHJ8/FprmvWEvv7p7NbUCPX6GcTahF46QrMIoAqEUeKzO744bd9Q==",
+      "requires": {
+        "source-map-support": "^0.5.16"
+      }
+    },
+    "appcd-request": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/appcd-request/-/appcd-request-2.2.0.tgz",
+      "integrity": "sha512-IdDl0TzR1h0sjBeEEUJ9RdOeYwcC09ydoU06IflqmvQkaGfB5lCM+GLJQLRFdXCwAYx/MjY1AK3M+DB5as6PHA==",
+      "requires": {
+        "appcd-dispatcher": "^2.0.3",
+        "appcd-fs": "^1.1.10",
+        "appcd-logger": "^2.0.5",
+        "humanize": "^0.0.9",
+        "request": "^2.88.0",
+        "source-map-support": "^0.5.16"
+      }
+    },
+    "appcd-response": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/appcd-response/-/appcd-response-2.0.4.tgz",
+      "integrity": "sha512-9QzB7XpqhuSUc8mToIl5zqgzFrfC87oX30smmhUDOlllFDuxOQmOKLWWHtfgDOLyoPNidHLIVhLxiQNklzKaoQ==",
+      "requires": {
+        "appcd-fs": "^1.1.10",
+        "appcd-path": "^1.1.9",
+        "source-map-support": "^0.5.16",
+        "sprintf-js": "^1.1.2"
+      }
+    },
+    "appcd-subprocess": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/appcd-subprocess/-/appcd-subprocess-3.0.2.tgz",
+      "integrity": "sha512-iABedfJHOlVXDWQGr1KnBV6HTKwj+440iZsVVXplLwIl/5rdm3e/wDyaBp2W7kVZLWvQbsLLUv+mg5eaGld+yA==",
+      "requires": {
+        "appcd-dispatcher": "^2.0.3",
+        "appcd-logger": "^2.0.5",
+        "appcd-nodejs": "^3.0.2",
+        "appcd-path": "^1.1.9",
+        "appcd-response": "^2.0.3",
+        "appcd-util": "^2.0.2",
+        "gawk": "^4.7.0",
+        "ps-tree": "^1.2.0",
+        "source-map-support": "^0.5.16",
+        "which": "^2.0.2"
+      },
+      "dependencies": {
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
+    "appcd-util": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/appcd-util/-/appcd-util-2.0.2.tgz",
+      "integrity": "sha512-57fIlDxdrENiist+uBv/1GsyQxC2vJhldxmXk5O+ue4WMtD8BdLDTmy4zX3aXtiFDGF4bTc4Hw1gEHauyWqHSA==",
+      "requires": {
+        "appcd-fs": "^1.1.10",
+        "lodash.get": "^4.4.2",
+        "semver": "^7.1.1",
+        "source-map-support": "^0.5.16"
+      }
+    },
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
@@ -11004,6 +11141,64 @@
         }
       }
     },
+    "snooplogg": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/snooplogg/-/snooplogg-2.3.3.tgz",
+      "integrity": "sha512-ibqjTxEjn4axSxl+bX17h71ioK/MN8xHdaLFNAkyqHvywOI5xqT7blyUm6ALPDYzfVNIe6Itr+61odaVSEU20A==",
+      "requires": {
+        "bryt": "^1.0.1",
+        "chalk": "^3.0.0",
+        "nanobuffer": "^1.1.6",
+        "source-map-support": "^0.5.16",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "socks": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.3.3.tgz",
@@ -12027,9 +12222,9 @@
       "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
     },
     "titanium-editor-commons": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/titanium-editor-commons/-/titanium-editor-commons-1.0.1.tgz",
-      "integrity": "sha512-/sqjX8IGckJBc0gtQCLhrl0sqA05KblPUIekkX/eNcUs386N/A4YNDTrKerAPFuzH9VpfZNrQxEgbanjGrs7gQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/titanium-editor-commons/-/titanium-editor-commons-1.0.2.tgz",
+      "integrity": "sha512-tDbZBkmc47x9uvDKTWmhVXwldBhuc+m1x1Cx9GB2TCrkl0KjrIFrVjJmE/K1q4+j8eLuIe4gjMp6VTbhe4mkbg==",
       "requires": {
         "appcd-subprocess": "^3.0.1",
         "fs-extra": "^9.0.0",
@@ -12037,224 +12232,6 @@
         "libnpm": "^3.0.1",
         "semver": "^7.1.3",
         "titaniumlib": "^3.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-          "requires": {
-            "@types/color-name": "^1.1.1",
-            "color-convert": "^2.0.1"
-          }
-        },
-        "appcd-dispatcher": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/appcd-dispatcher/-/appcd-dispatcher-2.0.3.tgz",
-          "integrity": "sha512-WmcHdKjIlLjhvjx1XDCQS6MEaQIeqYa3TAT5Tn0impvMaJXYZRwTsQuiB4bcjFpo/MYjL84R4a1plwn22B9kpg==",
-          "requires": {
-            "appcd-logger": "^2.0.5",
-            "appcd-response": "^2.0.3",
-            "gawk": "^4.7.0",
-            "path-to-regexp": "^6.1.0",
-            "pluralize": "^8.0.0",
-            "source-map-support": "^0.5.16",
-            "uuid": "^3.3.3"
-          }
-        },
-        "appcd-fs": {
-          "version": "1.1.10",
-          "resolved": "https://registry.npmjs.org/appcd-fs/-/appcd-fs-1.1.10.tgz",
-          "integrity": "sha512-hLtsgLpR5T5HacraXPCjtNP8yDc9sdGx6cLie0PoutwvhqVJcpkD1LXRLRweKBM/O/Nwwyb8Ry3Um/HxCtMN9g==",
-          "requires": {
-            "source-map-support": "^0.5.16"
-          }
-        },
-        "appcd-logger": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/appcd-logger/-/appcd-logger-2.0.5.tgz",
-          "integrity": "sha512-/YHgZEYBKijfp00TvpfCFmRMOqQ9NGRqJ3ydX513+3NztaNDpd5MPzKKwLnbAMEHTS+ttWEpCNpDMcWOyhRh6A==",
-          "requires": {
-            "snooplogg": "^2.3.3",
-            "source-map-support": "^0.5.16"
-          }
-        },
-        "appcd-nodejs": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/appcd-nodejs/-/appcd-nodejs-3.0.2.tgz",
-          "integrity": "sha512-zsT8vrjs+dS6/ch0zJarrSP5IOuTRcHoKaWbpHfpVfu0nCQqjjCHzfKEMjhnoJeekIJlU17o0mXrvRo82dQ9+g==",
-          "requires": {
-            "appcd-fs": "^1.1.10",
-            "appcd-logger": "^2.0.5",
-            "appcd-request": "^2.2.0",
-            "appcd-util": "^2.0.2",
-            "fs-extra": "^8.1.0",
-            "pluralize": "^8.0.0",
-            "progress": "^2.0.3",
-            "source-map-support": "^0.5.16",
-            "tar-stream": "^2.1.0",
-            "yauzl": "^2.10.0"
-          },
-          "dependencies": {
-            "fs-extra": {
-              "version": "8.1.0",
-              "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-              "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-              "requires": {
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^4.0.0",
-                "universalify": "^0.1.0"
-              }
-            }
-          }
-        },
-        "appcd-path": {
-          "version": "1.1.10",
-          "resolved": "https://registry.npmjs.org/appcd-path/-/appcd-path-1.1.10.tgz",
-          "integrity": "sha512-SHVMoAjhwJIYkqrP3P8JdKGNOOfK9TTsGnXHJ8/FprmvWEvv7p7NbUCPX6GcTahF46QrMIoAqEUeKzO744bd9Q==",
-          "requires": {
-            "source-map-support": "^0.5.16"
-          }
-        },
-        "appcd-request": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/appcd-request/-/appcd-request-2.2.0.tgz",
-          "integrity": "sha512-IdDl0TzR1h0sjBeEEUJ9RdOeYwcC09ydoU06IflqmvQkaGfB5lCM+GLJQLRFdXCwAYx/MjY1AK3M+DB5as6PHA==",
-          "requires": {
-            "appcd-dispatcher": "^2.0.3",
-            "appcd-fs": "^1.1.10",
-            "appcd-logger": "^2.0.5",
-            "humanize": "^0.0.9",
-            "request": "^2.88.0",
-            "source-map-support": "^0.5.16"
-          }
-        },
-        "appcd-response": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/appcd-response/-/appcd-response-2.0.4.tgz",
-          "integrity": "sha512-9QzB7XpqhuSUc8mToIl5zqgzFrfC87oX30smmhUDOlllFDuxOQmOKLWWHtfgDOLyoPNidHLIVhLxiQNklzKaoQ==",
-          "requires": {
-            "appcd-fs": "^1.1.10",
-            "appcd-path": "^1.1.9",
-            "source-map-support": "^0.5.16",
-            "sprintf-js": "^1.1.2"
-          }
-        },
-        "appcd-subprocess": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/appcd-subprocess/-/appcd-subprocess-3.0.2.tgz",
-          "integrity": "sha512-iABedfJHOlVXDWQGr1KnBV6HTKwj+440iZsVVXplLwIl/5rdm3e/wDyaBp2W7kVZLWvQbsLLUv+mg5eaGld+yA==",
-          "requires": {
-            "appcd-dispatcher": "^2.0.3",
-            "appcd-logger": "^2.0.5",
-            "appcd-nodejs": "^3.0.2",
-            "appcd-path": "^1.1.9",
-            "appcd-response": "^2.0.3",
-            "appcd-util": "^2.0.2",
-            "gawk": "^4.7.0",
-            "ps-tree": "^1.2.0",
-            "source-map-support": "^0.5.16",
-            "which": "^2.0.2"
-          }
-        },
-        "appcd-util": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/appcd-util/-/appcd-util-2.0.2.tgz",
-          "integrity": "sha512-57fIlDxdrENiist+uBv/1GsyQxC2vJhldxmXk5O+ue4WMtD8BdLDTmy4zX3aXtiFDGF4bTc4Hw1gEHauyWqHSA==",
-          "requires": {
-            "appcd-fs": "^1.1.10",
-            "lodash.get": "^4.4.2",
-            "semver": "^7.1.1",
-            "source-map-support": "^0.5.16"
-          }
-        },
-        "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        },
-        "fs-extra": {
-          "version": "9.0.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
-          "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
-          "requires": {
-            "at-least-node": "^1.0.0",
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^1.0.0"
-          },
-          "dependencies": {
-            "jsonfile": {
-              "version": "6.0.1",
-              "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
-              "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
-              "requires": {
-                "graceful-fs": "^4.1.6",
-                "universalify": "^1.0.0"
-              }
-            },
-            "universalify": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-              "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug=="
-            }
-          }
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-        },
-        "path-to-regexp": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.0.tgz",
-          "integrity": "sha512-f66KywYG6+43afgE/8j/GoiNyygk/bnoCbps++3ErRKsIYkGGupyv07R2Ok5m9i67Iqc+T2g1eAUGUPzWhYTyg=="
-        },
-        "snooplogg": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/snooplogg/-/snooplogg-2.3.3.tgz",
-          "integrity": "sha512-ibqjTxEjn4axSxl+bX17h71ioK/MN8xHdaLFNAkyqHvywOI5xqT7blyUm6ALPDYzfVNIe6Itr+61odaVSEU20A==",
-          "requires": {
-            "bryt": "^1.0.1",
-            "chalk": "^3.0.0",
-            "nanobuffer": "^1.1.6",
-            "source-map-support": "^0.5.16",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        },
-        "which": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-          "requires": {
-            "isexe": "^2.0.0"
-          }
-        }
       }
     },
     "titaniumlib": {
@@ -12275,64 +12252,6 @@
         "yauzl": "^2.10.0"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-          "requires": {
-            "@types/color-name": "^1.1.1",
-            "color-convert": "^2.0.1"
-          }
-        },
-        "appcd-fs": {
-          "version": "1.1.10",
-          "resolved": "https://registry.npmjs.org/appcd-fs/-/appcd-fs-1.1.10.tgz",
-          "integrity": "sha512-hLtsgLpR5T5HacraXPCjtNP8yDc9sdGx6cLie0PoutwvhqVJcpkD1LXRLRweKBM/O/Nwwyb8Ry3Um/HxCtMN9g==",
-          "requires": {
-            "source-map-support": "^0.5.16"
-          }
-        },
-        "appcd-path": {
-          "version": "1.1.10",
-          "resolved": "https://registry.npmjs.org/appcd-path/-/appcd-path-1.1.10.tgz",
-          "integrity": "sha512-SHVMoAjhwJIYkqrP3P8JdKGNOOfK9TTsGnXHJ8/FprmvWEvv7p7NbUCPX6GcTahF46QrMIoAqEUeKzO744bd9Q==",
-          "requires": {
-            "source-map-support": "^0.5.16"
-          }
-        },
-        "appcd-util": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/appcd-util/-/appcd-util-2.0.2.tgz",
-          "integrity": "sha512-57fIlDxdrENiist+uBv/1GsyQxC2vJhldxmXk5O+ue4WMtD8BdLDTmy4zX3aXtiFDGF4bTc4Hw1gEHauyWqHSA==",
-          "requires": {
-            "appcd-fs": "^1.1.10",
-            "lodash.get": "^4.4.2",
-            "semver": "^7.1.1",
-            "source-map-support": "^0.5.16"
-          }
-        },
-        "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        },
         "fs-extra": {
           "version": "8.1.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -12342,11 +12261,6 @@
             "jsonfile": "^4.0.0",
             "universalify": "^0.1.0"
           }
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
         },
         "request": {
           "version": "2.88.2",
@@ -12373,26 +12287,6 @@
             "tough-cookie": "~2.5.0",
             "tunnel-agent": "^0.6.0",
             "uuid": "^3.3.2"
-          }
-        },
-        "snooplogg": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/snooplogg/-/snooplogg-2.3.3.tgz",
-          "integrity": "sha512-ibqjTxEjn4axSxl+bX17h71ioK/MN8xHdaLFNAkyqHvywOI5xqT7blyUm6ALPDYzfVNIe6Itr+61odaVSEU20A==",
-          "requires": {
-            "bryt": "^1.0.1",
-            "chalk": "^3.0.0",
-            "nanobuffer": "^1.1.6",
-            "source-map-support": "^0.5.16",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "requires": {
-            "has-flag": "^4.0.0"
           }
         },
         "tough-cookie": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "semver": "^7.3.2",
     "sinon": "^9.0.3",
     "sudo-prompt": "^9.2.1",
-    "titanium-editor-commons": "^1.0.1",
+    "titanium-editor-commons": "^1.0.2",
     "underscore": "^1.11.0",
     "xml2js": "^0.4.23"
   },

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
   "engines": {
     "atom": ">1.21.0"
   },
+  "activationHooks": [
+    "core:loaded-shell-environment"
+  ],
   "keywords": [
     "axway",
     "appcelerator",
@@ -54,11 +57,12 @@
   "dependencies": {
     "etch": "^0.12.6",
     "find": "^0.3.0",
+    "fs-extra": "^9.0.1",
     "mkdirp": "^1.0.4",
     "semver": "^7.3.2",
     "sinon": "^9.0.3",
     "sudo-prompt": "^9.2.1",
-    "titanium-editor-commons": "^0.5.1",
+    "titanium-editor-commons": "^1.0.1",
     "underscore": "^1.11.0",
     "xml2js": "^0.4.23"
   },

--- a/spec/controllerAutoCompleteProvider-spec.js
+++ b/spec/controllerAutoCompleteProvider-spec.js
@@ -34,7 +34,10 @@ describe('Ti namespace suggestions', function () {
 		this.timeout(5000);
 		sandbox = sinon.createSandbox();
 		atomEnvironment = global.buildAtomEnvironment();
+		await atomEnvironment.packages.triggerDeferredActivationHooks();
+		await atomEnvironment.packages.triggerActivationHook('core:loaded-shell-environment');
 		await atomEnvironment.packages.activatePackage(path.join(__dirname, '..'));
+		expect(atomEnvironment.packages.isPackageActive('appcelerator-titanium')).to.equal(true);
 		sandbox.stub(Project, 'sdk').resolves('8.1.0.GA');
 		sandbox.stub(tce.completion, 'loadCompletions').resolves(completions);
 	});
@@ -91,7 +94,10 @@ describe('Extended Ti suggestions', function () {
 		this.timeout(5000);
 		sandbox = sinon.createSandbox();
 		atomEnvironment = global.buildAtomEnvironment();
+		await atomEnvironment.packages.triggerDeferredActivationHooks();
+		await atomEnvironment.packages.triggerActivationHook('core:loaded-shell-environment');
 		await atomEnvironment.packages.activatePackage(path.join(__dirname, '..'));
+		expect(atomEnvironment.packages.isPackageActive('appcelerator-titanium')).to.equal(true);
 		sandbox.stub(Project, 'sdk').resolves('8.1.0.GA');
 		sandbox.stub(tce.completion, 'loadCompletions').resolves(completions);
 	});
@@ -139,7 +145,10 @@ describe('Alloy namespace suggestions', function () {
 		this.timeout(5000);
 		sandbox = sinon.createSandbox();
 		atomEnvironment = global.buildAtomEnvironment();
+		await atomEnvironment.packages.triggerDeferredActivationHooks();
+		await atomEnvironment.packages.triggerActivationHook('core:loaded-shell-environment');
 		await atomEnvironment.packages.activatePackage(path.join(__dirname, '..'));
+		expect(atomEnvironment.packages.isPackageActive('appcelerator-titanium')).to.equal(true);
 		sandbox.stub(Project, 'sdk').resolves('8.1.0.GA');
 		sandbox.stub(tce.completion, 'loadCompletions').resolves(completions);
 	});
@@ -172,7 +181,6 @@ describe('Alloy namespace suggestions', function () {
 			expect(suggestions[1].rightLabel).to.equal('Alloy');
 			expect(suggestions[1].snippet).to.equal('CFG');
 			expect(suggestions[1].priority).to.equal(2);
-			console.log(suggestions[2]);
 			expect(suggestions[2].type).to.equal('method');
 			expect(suggestions[2].displayText).to.equal('Alloy.Models');
 		} else {
@@ -197,7 +205,10 @@ describe('Extended Alloy suggestions', function () {
 		this.timeout(5000);
 		sandbox = sinon.createSandbox();
 		atomEnvironment = global.buildAtomEnvironment();
+		await atomEnvironment.packages.triggerDeferredActivationHooks();
+		await atomEnvironment.packages.triggerActivationHook('core:loaded-shell-environment');
 		await atomEnvironment.packages.activatePackage(path.join(__dirname, '..'));
+		expect(atomEnvironment.packages.isPackageActive('appcelerator-titanium')).to.equal(true);
 		sandbox.stub(Project, 'sdk').resolves('8.1.0.GA');
 		sandbox.stub(tce.completion, 'loadCompletions').resolves(completions);
 	});

--- a/spec/styleAutoCompleteProvider-spec.js
+++ b/spec/styleAutoCompleteProvider-spec.js
@@ -34,7 +34,10 @@ describe('Tag suggestions', function () {
 		this.timeout(5000);
 		sandbox = sinon.createSandbox();
 		atomEnvironment = global.buildAtomEnvironment();
+		await atomEnvironment.packages.triggerDeferredActivationHooks();
+		await atomEnvironment.packages.triggerActivationHook('core:loaded-shell-environment');
 		await atomEnvironment.packages.activatePackage(path.join(__dirname, '..'));
+		expect(atomEnvironment.packages.isPackageActive('appcelerator-titanium')).to.equal(true);
 		sandbox.stub(Project, 'sdk').resolves('8.1.0.GA');
 		sandbox.stub(tce.completion, 'loadCompletions').resolves(completions);
 	});
@@ -87,7 +90,10 @@ describe('Property suggestions', function () {
 		this.timeout(5000);
 		sandbox = sinon.createSandbox();
 		atomEnvironment = global.buildAtomEnvironment();
+		await atomEnvironment.packages.triggerDeferredActivationHooks();
+		await atomEnvironment.packages.triggerActivationHook('core:loaded-shell-environment');
 		await atomEnvironment.packages.activatePackage(path.join(__dirname, '..'));
+		expect(atomEnvironment.packages.isPackageActive('appcelerator-titanium')).to.equal(true);
 		sandbox.stub(Project, 'sdk').resolves('8.1.0.GA');
 		sandbox.stub(tce.completion, 'loadCompletions').resolves(completions);
 	});

--- a/spec/viewAutoCompleteProvider-spec.js
+++ b/spec/viewAutoCompleteProvider-spec.js
@@ -34,7 +34,10 @@ describe('Tag suggestions', function () {
 		this.timeout(5000);
 		sandbox = sinon.createSandbox();
 		atomEnvironment = global.buildAtomEnvironment();
+		await atomEnvironment.packages.triggerDeferredActivationHooks();
+		await atomEnvironment.packages.triggerActivationHook('core:loaded-shell-environment');
 		await atomEnvironment.packages.activatePackage(path.join(__dirname, '..'));
+		expect(atomEnvironment.packages.isPackageActive('appcelerator-titanium')).to.equal(true);
 		sandbox.stub(Project, 'sdk').resolves('8.1.0.GA');
 	});
 
@@ -89,7 +92,10 @@ describe('Attribute suggestions', function () {
 		this.timeout(5000);
 		sandbox = sinon.createSandbox();
 		atomEnvironment = global.buildAtomEnvironment();
+		await atomEnvironment.packages.triggerDeferredActivationHooks();
+		await atomEnvironment.packages.triggerActivationHook('core:loaded-shell-environment');
 		await atomEnvironment.packages.activatePackage(path.join(__dirname, '..'));
+		expect(atomEnvironment.packages.isPackageActive('appcelerator-titanium')).to.equal(true);
 		sandbox.stub(Project, 'sdk').resolves('8.1.0.GA');
 		sandbox.stub(tce.completion, 'loadCompletions').resolves(completions);
 	});


### PR DESCRIPTION
Adds the node update and install functionality to atom, I have tried to keep it almost identical to how atom does it, the editor commons will need to be updated before this is merged 