### PR TITLE
Support using OSS tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ appc:clean | `ctrl-alt-k`      | Clean the current project directory
 
 ### Build tools
 
+#### Selecting Tooling
+
+By default this package will use the Appcelerator CLI tooling. You can switch to the Titanium CLI tooling by enabling the `Use ti commands` property in the package settings. The toolbar will display `(appc)` when the Appcelerator tooling is enabled, and `(ti)` when the Titanium tooling is enabled.
+
 #### Toolbar
 
 The toolbar provides a UI to commonly used commands when developing a Titanium application. Further information on each function is provided in the sections below.

--- a/lib/appc.js
+++ b/lib/appc.js
@@ -43,7 +43,7 @@ const Appc = {
 	getInfo(callback) {
 		let result = '';
 		new BufferedProcess({
-			command: atom.config.get('appcelerator-titanium.general.appcCommandPath'),
+			command: Utils.getCommandName(),
 			args: [ 'info', '-o', 'json' ],
 			stdout: data => result += data,
 			stderr: () => this.showAppcCommandError('Error fetching environment information'),
@@ -321,7 +321,7 @@ const Appc = {
 		var errorMsg = Utils.usingAppcTooling() ? 'appc run' : 'ti build';
 
 		const proc = new BufferedProcess({
-			command: atom.config.get('appcelerator-titanium.general.appcCommandPath'),
+			command: Utils.getCommandName(),
 			args: [ runCmd ].concat(opts.args),
 			stdout: output => opts.log && opts.log(output),
 			stderr: output => opts.error && opts.error(output),
@@ -350,7 +350,7 @@ const Appc = {
 			args = args.concat(opts.args);
 		}
 
-		var runCmd = atom.config.get('appcelerator-titanium.general.appcCommandPath');
+		let runCmd = Utils.getCommandName();
 
 		if (!Utils.usingAppcTooling()) {
 			runCmd = 'alloy';
@@ -426,7 +426,7 @@ const Appc = {
 			platforms: opts.platforms,
 			workspaceDir: opts.location
 		});
-		const command = atom.config.get('appcelerator-titanium.general.appcCommandPath');
+		const command = Utils.getCommandName();
 		const projectDir = path.join(opts.location, opts.name);
 		function handleFinish(code) {
 			opts.callback && opts.callback();
@@ -488,7 +488,7 @@ const Appc = {
 			return;
 		}
 		const proc = new BufferedProcess({
-			command: atom.config.get('appcelerator-titanium.general.appcCommandPath'),
+			command: Utils.getCommandName(),
 			args: [ 'login',
 				'--no-banner',
 				'-q',
@@ -519,7 +519,7 @@ const Appc = {
 		return new Promise((resolve, reject) => {
 			let result = '';
 			new BufferedProcess({
-				command: atom.config.get('appcelerator-titanium.general.appcCommandPath'),
+				command: Utils.getCommandName(),
 				args: [ 'platform', '/auth/checkSession', 'GET', '-o', 'json' ],
 				stdout: data => {
 					if ((/Appcelerator Login required to continue /g).exec(data)) {
@@ -562,7 +562,7 @@ const Appc = {
 	 *
 	 */
 	clean(opts) {
-		const command = atom.config.get('appcelerator-titanium.general.appcCommandPath');
+		const command = Utils.getCommandName();
 		const args = Utils.usingAppcTooling() ? [ 'ti', 'clean' ] : [ 'clean' ];
 
 		const proc = new BufferedProcess({

--- a/lib/appc.js
+++ b/lib/appc.js
@@ -518,45 +518,25 @@ const Appc = {
 		}
 		return new Promise((resolve, reject) => {
 			let result = '';
-			this.testAppcCommand(success => {
-				if (success) {
-					new BufferedProcess({
-						command: atom.config.get('appcelerator-titanium.general.appcCommandPath'),
-						args: [ 'platform', '/auth/checkSession', 'GET', '-o', 'json' ],
-						stdout: data => {
-							if ((/Appcelerator Login required to continue /g).exec(data)) {
-								return reject();
-							}
-							result += data;
-						},
-						stderr: () => { return reject(); },
-						exit: () => {
-							if (result && result.length) {
-								result = JSON.parse(result);
-								resolve(result);
-							}
-						}
-					});
+			new BufferedProcess({
+				command: atom.config.get('appcelerator-titanium.general.appcCommandPath'),
+				args: [ 'platform', '/auth/checkSession', 'GET', '-o', 'json' ],
+				stdout: data => {
+					if ((/Appcelerator Login required to continue /g).exec(data)) {
+						return reject();
+					}
+					result += data;
+				},
+				stderr: () => { return reject(); },
+				exit: () => {
+					if (result && result.length) {
+						result = JSON.parse(result);
+						resolve(result);
+					}
 				}
 			});
 		}).catch(() => {
 			atom.notifications.addError('No valid session was found, please login.');
-		});
-	},
-
-	/**
-	 * Test appc command
-	 *
-	 * @param {Function} callback 	calback function
-	 */
-	testAppcCommand(callback) {
-		new BufferedProcess({
-			command: atom.config.get('appcelerator-titanium.general.appcCommandPath'),
-			args: [ '-v' ],
-			exit: code => callback && callback(code === 0)
-		}).onWillThrowError(error => {
-			error.handle();
-			callback && callback(false);
 		});
 	},
 
@@ -602,29 +582,6 @@ const Appc = {
 		});
 
 		return proc;
-	},
-	installSDK(opts) {
-		var runArgs = [ 'ti', 'sdk', 'install', opts.version, '--default' ];
-		if (atom.config.get('appcelerator-titanium.general.useTi')) {
-			runArgs.shift();
-		}
-
-		const proc = new BufferedProcess({
-			command: atom.config.get('appcelerator-titanium.general.appcCommandPath'),
-			options: {
-				cwd: atom.project.getPaths()[0]
-			},
-			args: runArgs,
-			stdout: output => opts.log && opts.log(output),
-			stderr: output => opts.error && opts.error(output),
-			exit: code => opts.callback && opts.callback(code)
-		});
-		proc.onWillThrowError(error => {
-			var errorMsg = atom.config.get('appcelerator-titanium.general.useTi') ? 'ti' : 'appc ti';
-			this.showAppcCommandError('Error executing \'' + errorMsg + ' sdk install\' command');
-			error.handle();
-			opts.callback && opts.callback(1);
-		});
 	}
 };
 

--- a/lib/appc.js
+++ b/lib/appc.js
@@ -1,7 +1,6 @@
 'use babel';
 
 import { BufferedProcess } from 'atom';
-import { spawn } from 'child_process';
 import { homedir } from 'os';
 import fs from 'fs';
 import path from 'path';
@@ -317,15 +316,19 @@ const Appc = {
 	 * @returns {Object}
 	 */
 	run(opts) {
+
+		var runCmd = Utils.usingAppcTooling() ? 'run' : 'build';
+		var errorMsg = Utils.usingAppcTooling() ? 'appc run' : 'ti build';
+
 		const proc = new BufferedProcess({
 			command: atom.config.get('appcelerator-titanium.general.appcCommandPath'),
-			args: [ 'run' ].concat(opts.args),
+			args: [ runCmd ].concat(opts.args),
 			stdout: output => opts.log && opts.log(output),
 			stderr: output => opts.error && opts.error(output),
 			exit: code => opts.exit && opts.exit(code)
 		});
 		proc.onWillThrowError(error => {
-			this.showAppcCommandError('Error executing \'appc run\' command');
+			this.showAppcCommandError('Error executing \'' + errorMsg + '\' command');
 			error.handle();
 			opts.exit && opts.exit();
 		});
@@ -346,8 +349,16 @@ const Appc = {
 		if (opts.args && opts.args.length) {
 			args = args.concat(opts.args);
 		}
+
+		var runCmd = atom.config.get('appcelerator-titanium.general.appcCommandPath');
+
+		if (!Utils.usingAppcTooling()) {
+			runCmd = 'alloy';
+			args.shift();
+		}
+
 		new BufferedProcess({
-			command: atom.config.get('appcelerator-titanium.general.appcCommandPath'),
+			command: runCmd,
 			args,
 			options: {
 				cwd: atom.project.getPaths()[0]
@@ -408,44 +419,60 @@ const Appc = {
 	 * @param {Boolean} opts.enableServices		enable platform services
 	 */
 	new(opts) {
-		// test appc command first as unable to handle exception later
-		this.testAppcCommand(success => {
-			if (!success) {
-				this.showAppcCommandError('Error executing \'appc new\' command');
-				opts.callback && opts.callback();
+		const args = Utils.createAppArguments({
+			id: opts.id,
+			enableServices: opts.enableServices,
+			name: opts.name,
+			platforms: opts.platforms,
+			workspaceDir: opts.location
+		});
+		const command = atom.config.get('appcelerator-titanium.general.appcCommandPath');
+		const projectDir = path.join(opts.location, opts.name);
+		function handleFinish(code) {
+			opts.callback && opts.callback();
+			if (code === 0) {
+				// spawn process to open project in new window
+				return new BufferedProcess({
+					command: 'atom',
+					args: [ projectDir ]
+				});
 			} else {
-				const args = Utils.createAppArguments({
-					id: opts.id,
-					enableServices: opts.enableServices,
-					name: opts.name,
-					platforms: opts.platforms,
-					workspaceDir: opts.location
-				});
-				const proc = spawn(atom.config.get('appcelerator-titanium.general.appcCommandPath'), args, {
-					shell: true
-				});
-				proc.stdout.on('data', (output) => {
-					const columnExp = /Would you like to enable the Appcelerator Test service for this app/g;
+				atom.notifications.addError('Error creating the application');
+			}
+		}
 
-					if (columnExp.exec(output.toString())) {
-						proc.stdin.write('n\n');
-					}
-				});
-				proc.stderr.on('data', (output) => opts.error && opts.error(output));
+		const proc = new BufferedProcess({
+			command,
+			args,
+			stdout: output => opts.log && opts.log(output, proc),
+			stderr: output => opts.error && opts.error(output),
+			exit: code => {
+				if (code || command === 'appc') {
+					return handleFinish(code);
+				}
 
-				proc.on('close', (code) => {
-					opts.callback && opts.callback();
-					if (code === 0) {
-						// spawn process to open project in new window
-						return new BufferedProcess({
-							command: 'atom',
-							args: [ path.join(opts.location, opts.name) ]
-						});
-					} else {
-						atom.notifications.addError('Error executing \'appc new\' command, the application was not created');
-					}
+				opts.log && opts.log('Creating Alloy app');
+				// create an alloy app now!
+				const proc = new BufferedProcess({
+					command: 'alloy',
+					args: [ 'new' ],
+					options: { cwd: projectDir },
+					stdout: output => opts.log && opts.log(output, proc),
+					stderr: output => opts.error && opts.error(output),
+					exit: code => handleFinish(code)
+				});
+				proc.onWillThrowError(error => {
+					this.showAppcCommandError('Error creating Alloy project');
+					error.handle();
+					opts.exit && opts.exit();
 				});
 			}
+		});
+
+		proc.onWillThrowError(error => {
+			this.showAppcCommandError('Error creating project');
+			error.handle();
+			opts.exit && opts.exit();
 		});
 	},
 
@@ -457,33 +484,27 @@ const Appc = {
 	 * @param {String} opts.password 			appc password
 	 */
 	login(opts) {
-		// test appc command first as unable to handle exception later
-		this.testAppcCommand(success => {
-			if (!success) {
-				this.showAppcCommandError('Error executing \'appc login\' command');
-				opts.callback && opts.callback();
-			} else {
-				const proc = new BufferedProcess({
-					command: atom.config.get('appcelerator-titanium.general.appcCommandPath'),
-					args: [ 'login',
-						'--no-banner',
-						'-q',
-						'--username',
-						opts.username,
-						'--password',
-						opts.password
-					],
-					stdout: output => opts.log && opts.log(output, proc),
-					stderr: output => opts.error && opts.error(output),
-					exit: code => opts.exit && opts.exit(code)
-				});
-				proc.onWillThrowError(error => {
-					this.showAppcCommandError('Error executing \'appc login\' command');
-					error.handle();
-					opts.exit && opts.exit();
-				});
-				return proc;
-			}
+		if (!Utils.usingAppcTooling()) {
+			return;
+		}
+		const proc = new BufferedProcess({
+			command: atom.config.get('appcelerator-titanium.general.appcCommandPath'),
+			args: [ 'login',
+				'--no-banner',
+				'-q',
+				'--username',
+				opts.username,
+				'--password',
+				opts.password
+			],
+			stdout: output => opts.log && opts.log(output, proc),
+			stderr: output => opts.error && opts.error(output),
+			exit: code => opts.exit && opts.exit(code)
+		});
+		proc.onWillThrowError(error => {
+			this.showAppcCommandError('Error executing \'appc login\' command');
+			error.handle();
+			opts.exit && opts.exit();
 		});
 	},
 
@@ -492,6 +513,9 @@ const Appc = {
 	 *@returns {Promise}
 		*/
 	getCurrentSession() {
+		if (!Utils.usingAppcTooling()) {
+			return;
+		}
 		return new Promise((resolve, reject) => {
 			let result = '';
 			this.testAppcCommand(success => {
@@ -517,7 +541,6 @@ const Appc = {
 			});
 		}).catch(() => {
 			atom.notifications.addError('No valid session was found, please login.');
-
 		});
 	},
 
@@ -559,18 +582,21 @@ const Appc = {
 	 *
 	 */
 	clean(opts) {
+		const command = atom.config.get('appcelerator-titanium.general.appcCommandPath');
+		const args = Utils.usingAppcTooling() ? [ 'ti', 'clean' ] : [ 'clean' ];
+
 		const proc = new BufferedProcess({
-			command: atom.config.get('appcelerator-titanium.general.appcCommandPath'),
+			command,
 			options: {
 				cwd: atom.project.getPaths()[0]
 			},
-			args: [ 'ti', 'clean' ],
+			args,
 			stdout: output => opts.log && opts.log(output),
 			stderr: output => opts.error && opts.error(output),
 			exit: code => opts.exit && opts.exit(code)
 		});
 		proc.onWillThrowError(error => {
-			this.showAppcCommandError('Error executing \'appc ti clean\' command');
+			this.showAppcCommandError(`Error executing ${command} ${args}`);
 			error.handle();
 			opts.exit && opts.exit();
 		});
@@ -578,18 +604,24 @@ const Appc = {
 		return proc;
 	},
 	installSDK(opts) {
+		var runArgs = [ 'ti', 'sdk', 'install', opts.version, '--default' ];
+		if (atom.config.get('appcelerator-titanium.general.useTi')) {
+			runArgs.shift();
+		}
+
 		const proc = new BufferedProcess({
 			command: atom.config.get('appcelerator-titanium.general.appcCommandPath'),
 			options: {
 				cwd: atom.project.getPaths()[0]
 			},
-			args: [ 'ti', 'sdk', 'install', opts.version, '--default' ],
+			args: runArgs,
 			stdout: output => opts.log && opts.log(output),
 			stderr: output => opts.error && opts.error(output),
 			exit: code => opts.callback && opts.callback(code)
 		});
 		proc.onWillThrowError(error => {
-			this.showAppcCommandError('Error executing \'appc ti sdk install\' command');
+			var errorMsg = atom.config.get('appcelerator-titanium.general.useTi') ? 'ti' : 'appc ti';
+			this.showAppcCommandError('Error executing \'' + errorMsg + ' sdk install\' command');
 			error.handle();
 			opts.callback && opts.callback(1);
 		});

--- a/lib/index.js
+++ b/lib/index.js
@@ -39,13 +39,6 @@ export default {
 			type: 'object',
 			title: 'General',
 			properties: {
-				appcCommandPath: {
-					type: 'string',
-					default: 'appc',
-					title: 'Path to \'appc\' or \'ti\' command',
-					description: 'Set the full path to the `appc` or `ti` (enable `ti` command below) command if Atom is unable to locate it. NOTE: Requires relaunch.',
-					order: 1
-				},
 				screenshotPath: {
 					type: 'string',
 					default: os.homedir(),
@@ -359,13 +352,8 @@ export default {
 			atom.config.onDidChange('appcelerator-titanium.general.showToolbar', () => {
 				this.toolbar.toggle();
 			});
-			atom.config.onDidChange('appcelerator-titanium.general.useTi', async (e) => {
-				if (e.newValue) {
-					atom.config.set('appcelerator-titanium.general.appcCommandPath', 'ti');
-				} else {
-					atom.config.set('appcelerator-titanium.general.appcCommandPath', '');
-				}
-				await this.prepare();
+			atom.config.onDidChange('appcelerator-titanium.general.useTi', async () => {
+				this.prepare();
 				setHud();
 				this.toolbar.update();
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -42,8 +42,8 @@ export default {
 				appcCommandPath: {
 					type: 'string',
 					default: 'appc',
-					title: 'Path to \'appc\' command',
-					description: 'Set the full path to the `appc` command if Atom is unable to locate it. NOTE: Requires relaunch.',
+					title: 'Path to \'appc\' or \'ti\' command',
+					description: 'Set the full path to the `appc` or `ti` (enable `ti` command below) command if Atom is unable to locate it. NOTE: Requires relaunch.',
 					order: 1
 				},
 				screenshotPath: {
@@ -66,6 +66,13 @@ export default {
 					title: 'Show Appcelerator toolbar',
 					description: 'Show or hide the Appcelerator top toolbar with all menu buttons.',
 					order: 5
+				},
+				useTi: {
+					type: 'boolean',
+					default: false,
+					title: 'Use ti commands',
+					description: 'Use ti commands instead of appc. Set the Path above to `ti`',
+					order: 6
 				}
 			}
 		},
@@ -207,9 +214,11 @@ export default {
 				return;
 			}
 
+			const cliCmd = Utils.usingAppcTooling() ? 'appc' : 'ti';
+
 			this.toolbar.hud.display({
 				icon: Project.appIcon(),
-				text: Project.appName() + ' | ' + Project.sdk(),
+				text: Project.appName() + ' | ' + Project.sdk() + ' | ' + cliCmd,
 				default: true
 			});
 			this.toolbar.update();
@@ -350,69 +359,31 @@ export default {
 			atom.config.onDidChange('appcelerator-titanium.general.showToolbar', () => {
 				this.toolbar.toggle();
 			});
-			const text = (Project.isTitaniumApp) ? `${Project.appName()} | ${Project.sdk()}` : `${Project.appName()} | ${Project.platforms().map(platform => Utils.nameForPlatform(platform)).join(', ')}`;
-			this.toolbar.hud.display({
-				icon: Project.appIcon(),
-				text: text,
-				default: true
-			});
-
-			this.toolbar.hud.display({
-				text: 'Preparing...',
-				spinner: true
-			});
-
-			const setupTargets = () => {
-				autoCompleteHelper.generateAutoCompleteSuggestions();
-				if (os.platform() === 'darwin') {
-					this.toolbar.populateiOSTargets();
+			atom.config.onDidChange('appcelerator-titanium.general.useTi', async (e) => {
+				if (e.newValue) {
+					atom.config.set('appcelerator-titanium.general.appcCommandPath', 'ti');
 				} else {
-					this.toolbar.populateAndroidTargets();
+					atom.config.set('appcelerator-titanium.general.appcCommandPath', '');
 				}
-				this.toolbar.update({ disableUI: false });
-				this.toolbar.hud.displayDefault();
-				this.toolbar.LoginDetails();
-				this.checkForUpdates();
+				await this.prepare();
+				setHud();
+				this.toolbar.update();
+
+			});
+
+			const setHud = () => {
+				const cliCmd = Utils.usingAppcTooling() ? 'appc' : 'ti';
+				const text = (Project.isTitaniumApp) ? `${Project.appName()} | ${Project.sdk()} (${cliCmd})` : `${Project.appName()} | ${Project.platforms().map(platform => Utils.nameForPlatform(platform)).join(', ')}`;
+				this.toolbar.hud.display({
+					icon: Project.appIcon(),
+					text: text,
+					default: true
+				});
 			};
+			setHud();
 
-			const { missing } = await environment.validateEnvironment();
+			await this.prepare();
 
-			if (missing.length) {
-				let message = 'You are missing the following required components for Titanium development:';
-				for (let i = 0; i < missing.length; i++) {
-					const product = missing[i];
-					if (i < missing.length - 1) {
-						message = `${message} ${product.name},`;
-					} else {
-						message = `${message} ${product.name}`;
-					}
-				}
-				message = `${message}. Without these components the package will be unusable.`;
-
-				const errorNotification = atom.notifications.addError(message, {
-					buttons: [
-						{
-							onDidClick: async () => {
-								errorNotification.dismiss();
-								const updateInfo = [];
-								for (const product of missing) {
-									updateInfo.push(await product.getInstallInfo());
-								}
-								await Update.installUpdates(updateInfo, this.toolbar);
-								Appc.getInfo(() => {
-									setupTargets();
-								});
-							},
-							text: 'Install'
-						}
-					],
-					dismissable: true,
-				});
-			} else {
-				Appc.getInfo(() => {
-					setupTargets();
-				});
-			}
 		} else {
 			if (this.toolbar) {
 				this.toolbar.destroy();
@@ -721,7 +692,8 @@ export default {
 			spinner: true
 		});
 		if (atom.config.get('appcelerator-titanium.general.displayBuildCommandInConsole')) {
-			this.console.write(`appc run ${options.args.join(' ')}`);
+			const cliCmd = Utils.usingAppcTooling() ? 'appc run' : 'ti build';
+			this.console.write(cliCmd + ' ' + options.args.join(' '));
 		}
 		this.runProc = Appc.run(options);
 		this.toolbar.update({ buildInProgress: true });
@@ -785,7 +757,7 @@ export default {
 		};
 		this.console.clear();
 		this.console.show(true);
-		this.console.write('appc ti clean');
+		this.console.write(Utils.usingAppcTooling() ? 'appc ti clean' : 'ti clean');
 		this.runProc = Appc.clean(options);
 		this.toolbar.update({ buildInProgress: true });
 	},
@@ -795,6 +767,10 @@ export default {
 	 * @param {Function} callback - Function to call once login has completed.
 	 */
 	runLogin(callback) {
+		if (!Utils.usingAppcTooling()) {
+			atom.notifications.addError('Disable `ti` commands in the settings to login.');
+			return;
+		}
 		let loginPanel;
 		this.loginDialog = new LoginDialog({
 			cancel: () => {
@@ -957,6 +933,9 @@ export default {
 	 * @returns {Boolean}
 	 */
 	checkLoginAndPrompt() {
+		if (!Utils.usingAppcTooling()) {
+			return;
+		}
 		return new Promise((resolve, reject) => {
 			if (!Appc.isUserLoggedIn()) {
 				this.runLogin((failed) => {
@@ -988,6 +967,74 @@ export default {
 			return path.parse(editor.getPath()).ext.substr(1) !== type;
 		} else {
 			return false;
+		}
+	},
+
+	async prepare () {
+
+		this.toolbar.update({ disableUI: true });
+
+		this.toolbar.hud.display({
+			text: 'Preparing...',
+			spinner: true
+		});
+
+		const setupTargets = () => {
+			autoCompleteHelper.generateAutoCompleteSuggestions();
+			if (os.platform() === 'darwin') {
+				this.toolbar.populateiOSTargets();
+			} else {
+				this.toolbar.populateAndroidTargets();
+			}
+			this.toolbar.update({ disableUI: false });
+			this.toolbar.hud.displayDefault();
+			if (Utils.usingAppcTooling()) {
+				this.toolbar.LoginDetails();
+			}
+			this.checkForUpdates();
+		};
+
+		const { missing } = await environment.validateEnvironment(undefined, Utils.usingAppcTooling());
+
+		if (missing.length) {
+			let message = 'You are missing the following required components for Titanium development:';
+			for (let i = 0; i < missing.length; i++) {
+				const product = missing[i];
+				if (i < missing.length - 1) {
+					message = `${message} ${product.name},`;
+				} else {
+					message = `${message} ${product.name}`;
+				}
+			}
+			message = `${message}. Without these components the package will be unusable.`;
+
+			const errorNotification = atom.notifications.addError(message, {
+				buttons: [
+					{
+						onDidClick: async () => {
+							errorNotification.dismiss();
+							const updateInfo = [];
+							for (const product of missing) {
+								updateInfo.push(await product.getInstallInfo());
+							}
+							await Update.installUpdates(updateInfo, this.toolbar);
+							Appc.getInfo(() => {
+								setupTargets();
+							});
+						},
+						text: 'Install'
+					}
+				],
+				dismissable: true,
+			});
+
+			this.toolbar.hud.display({
+				text: 'You are missing required tooling'
+			});
+		} else {
+			Appc.getInfo(() => {
+				setupTargets();
+			});
 		}
 	}
 };

--- a/lib/ui/newProjectDialog.jsx
+++ b/lib/ui/newProjectDialog.jsx
@@ -36,7 +36,7 @@ export default class NewProjectDialog {
 			id: '',
 			platforms: Utils.platforms(),
 			location: homedir(),
-			enableServices: true,
+			enableServices: Utils.usingAppcTooling(),
 		};
 		etch.initialize(this);
 		this.setFocus();
@@ -116,10 +116,12 @@ export default class NewProjectDialog {
 					<Button flat="true" icon="file-directory" disabled={this.state.executing} click={this.locationButtonClicked.bind(this)} />
 				</div>
 				{projectLocation}
-				<div className="row">
-					<div className="title">Enable Services:</div>
-					<input className="input-checkbox" type="checkbox" ref="enableServices" disabled={this.state.executing} checked={this.project.enableServices} on={{ change: this.enableServicesDidChange }} />
-				</div>
+				{ Utils.usingAppcTooling() ? (
+					<div className="row">
+						<div className="title">Enable Services:</div>
+						<input className="input-checkbox" type="checkbox" ref="enableServices" disabled={this.state.executing} checked={this.project.enableServices} on={{ change: this.enableServicesDidChange }} />
+					</div>
+				) : null}
 				{services}
 				<div className="row-buttons">
 					<button className="btn" attributes={{ tabindex: '10' }} disabled={this.state.executing} on={{ click: this.cancelButtonClicked }}>Cancel</button>

--- a/lib/ui/newProjectDialog.jsx
+++ b/lib/ui/newProjectDialog.jsx
@@ -198,8 +198,8 @@ export default class NewProjectDialog {
 	/**
 	 * Location button clicked
 	 */
-	locationButtonClicked() {
-		const filePaths = remote.dialog.showOpenDialog({ defaultPath: this.project.location, buttonLabel: 'Choose', properties: [ 'openDirectory', 'createDirectory' ] });
+	async locationButtonClicked() {
+		const { filePaths } = await remote.dialog.showOpenDialog({ defaultPath: this.project.location, buttonLabel: 'Choose', properties: [ 'openDirectory', 'createDirectory' ] });
 		if (filePaths && filePaths[0].length > 0) {
 			this.project.location = filePaths[0];
 		}

--- a/lib/ui/toolbar.jsx
+++ b/lib/ui/toolbar.jsx
@@ -268,7 +268,11 @@ export default class Toolbar {
 					<div className="toolbar-right main-toolbar-group">
 						<Button icon="plus" title="Create new..." className="button-right" flat="true" disabled={this.state.disableUI || !Project.isTitaniumApp} click={this.generateButtonClicked.bind(this)} />
 						<Button icon="terminal" title="Toggle console" className="button-right" flat="true" disabled={this.state.disableUI} click={this.toggleConsoleButtonClicked.bind(this)} />
-						<Button ref="loginDetails" icon={userButtonIcon} title={this.loginDetails} className="button-right" flat="true" disabled={this.state.disableUI} click={this.userProfile.bind(this)} />
+						{
+							Utils.usingAppcTooling()
+								? <Button ref="loginDetails" icon={userButtonIcon} title={this.loginDetails} className="button-right" flat="true" disabled={this.state.disableUI} click={this.userProfile.bind(this)} />
+								: null
+						}
 						<Button icon="x" title="Hide Toolbar" className="button-right" flat="true" click={this.toggle.bind(this)} />
 					</div>
 

--- a/lib/ui/updatesDialog.jsx
+++ b/lib/ui/updatesDialog.jsx
@@ -2,7 +2,7 @@
 /** @jsx etch.dom */
 
 import etch from 'etch';
-import { updates } from 'titanium-editor-commons';
+import Update from '../update';
 
 /**
  * Generate component dialog
@@ -88,7 +88,7 @@ export default class UpdatesDialog {
 	 */
 	async pullUpdate() {
 		this.state.checking = true;
-		this.state.updates = await updates.checkAllUpdates();
+		this.state.updates = await Update.getUpdates();
 		this.state.checking = false;
 		for (let index = 0; index < this.state.updates.length; index++) {
 			this.state.updates[index].selected = true;

--- a/lib/update.js
+++ b/lib/update.js
@@ -15,7 +15,7 @@ const Update = {
 
 		try {
 			const supportedVersions = await Utils.getNodeSupportedVersion(Project.sdk()[0]);
-			this.updates = await updates.checkAllUpdates({ nodeJS: supportedVersions });
+			this.updates = await updates.checkAllUpdates({ nodeJS: supportedVersions }, Utils.usingAppcTooling());
 		} catch (error) {
 			// console.log(error);
 		}
@@ -24,6 +24,13 @@ const Update = {
 			return this.updates;
 		}
 
+	},
+
+	async getUpdates() {
+		if (!this.updates) {
+			return this.refresh();
+		}
+		return this.updates;
 	},
 
 	async installUpdates (updateInfo, progress, incrementUpdate = false) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -321,5 +321,13 @@ export default {
 
 	usingAppcTooling() {
 		return !atom.config.get('appcelerator-titanium.general.useTi');
+	},
+
+	getCommandName() {
+		if (atom.config.get('appcelerator-titanium.general.useTi')) {
+			return 'ti';
+		} else {
+			return 'appc';
+		}
 	}
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -256,19 +256,26 @@ export default {
 	},
 
 	createAppArguments(options) {
+		const command = this.usingAppcTooling() ? 'create' : 'new';
 		const args = [
-			'new',
-			'--type', 'titanium',
+			command,
+			'--type', 'app',
 			'--name', options.name,
 			'--id', options.id,
-			'--project-dir', path.join(options.workspaceDir, options.name),
 			'--platforms', options.platforms.join(','),
 			'--no-prompt',
 			'--log-level', 'trace'
 		];
 
-		if (!options.enableServices) {
-			args.push('--no-services');
+		// appc cli expects a --project-dir argument that points to where the final directory should be,
+		// but titanium cli expects a --workspace-dir argument that points to where the project should be created
+		if (command === 'new') {
+			args.push('--project-dir', path.join(options.workspaceDir, options.name));
+			if (!options.enableServices) {
+				args.push('--no-services');
+			}
+		} else {
+			args.push('--workspace-dir', options.workspaceDir);
 		}
 
 		return args;
@@ -310,5 +317,9 @@ export default {
 		const packageJSON = path.join(sdkPath, 'package.json');
 		const { vendorDependencies } = await fs.readJSON(packageJSON);
 		return vendorDependencies.node;
+	},
+
+	usingAppcTooling() {
+		return !atom.config.get('appcelerator-titanium.general.useTi');
 	}
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -256,7 +256,7 @@ export default {
 	},
 
 	createAppArguments(options) {
-		const command = this.usingAppcTooling() ? 'create' : 'new';
+		const command = this.usingAppcTooling() ? 'new' : 'create';
 		const args = [
 			command,
 			'--type', 'app',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1739,7 +1739,6 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -2758,6 +2757,11 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+    },
+    "ci-info": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
+      "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A=="
     },
     "class-utils": {
       "version": "0.3.6",
@@ -4058,9 +4062,9 @@
       }
     },
     "env-paths": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.0.tgz",
-      "integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA=="
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="
     },
     "err-code": {
       "version": "1.1.2",
@@ -5286,8 +5290,7 @@
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-json-patch": {
       "version": "3.0.0-1",
@@ -5716,13 +5719,6 @@
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "source-map-support": "^0.5.19"
-      },
-      "dependencies": {
-        "fast-deep-equal": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
-        }
       }
     },
     "genfun": {
@@ -6211,24 +6207,6 @@
       "requires": {
         "ajv": "^6.12.3",
         "har-schema": "^2.0.0"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "6.12.6",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "fast-deep-equal": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
-        }
       }
     },
     "hard-rejection": {
@@ -6678,13 +6656,6 @@
       "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
       "requires": {
         "ci-info": "^1.5.0"
-      },
-      "dependencies": {
-        "ci-info": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
-          "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A=="
-        }
       }
     },
     "is-core-module": {
@@ -12235,9 +12206,9 @@
       "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
     },
     "titanium-editor-commons": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/titanium-editor-commons/-/titanium-editor-commons-1.0.4.tgz",
-      "integrity": "sha512-mh/aiwM6j2b73sSL5kB5QkuFUOZX0Nq925vpUPElmMCAcKOBljsz3cvbMdzgP/fGO4/jWuD8aw5d8uPmTTtpBA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/titanium-editor-commons/-/titanium-editor-commons-1.2.0.tgz",
+      "integrity": "sha512-+f+x/h8GxQGEyfYlmx6AihzolLAnLkUzwIluTMUxxbpIyDtl0An8ZZaGVwafcippRSN06mTwM3xxqmszZ/qvAw==",
       "requires": {
         "appcd-subprocess": "^3.0.1",
         "fs-extra": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "mkdirp": "^1.0.4",
     "semver": "^7.3.5",
     "sudo-prompt": "^9.2.1",
-    "titanium-editor-commons": "^1.0.4",
+    "titanium-editor-commons": "^1.2.0",
     "underscore": "^1.11.0",
     "xml2js": "^0.4.23"
   },


### PR DESCRIPTION
This PR introduces support for using the Ti and Alloy (OSS) tooling directly instead of the Appc tooling. This is enabled by a setting in the package settings, the default for now is to continue to use Appc tooling.

There are a couple commits that are general bug fixes that I needed to fix to be able to test fully or refactoring of unused/unnecessary code, namely:

* baa7b00a288fddc622f5cafe38d82ff56c37acd8 - fixes an issue when selecting a folder during project creation
* 8e73adb42ab38266c532b8993e3e9153f865dc7b - removes unused/unnecessary code

All other commits are pertinent to supporting the OSS tooling separated into the different areas to make reviewing easier, and will be squashed into one commit prior to merge.