### PR TITLE
fix: exit 0 if husky errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "lint": "eslint --ext .js,.jsx .",
     "release": "semantic-release",
     "test": "apm --version && apm test",
-    "postinstall": "husky install",
+    "postinstall": "husky install || exit 0",
     "prepublishOnly": "pinst --disable",
     "postpublish": "pinst --enable"
   },


### PR DESCRIPTION
As atom will trigger the postinstall script we want to make sure we dont error there, so if the
husky install fails exit with 0