### PR TITLE
fix: check for existence of toolbar before performing target setup 

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -973,6 +973,11 @@ export default {
 		});
 
 		const setupTargets = () => {
+			// It's possible that the plugin has been unloaded as the folder was removed whilst
+			// we were running appc info. So check for the existence of the toolbar and return
+			if (!this.toolbar) {
+				return;
+			}
 			autoCompleteHelper.generateAutoCompleteSuggestions();
 			this.toolbar.refreshTargets();
 			this.toolbar.update({ disableUI: false });


### PR DESCRIPTION
It's possible the toolbar has been uploaded between calling getInfo and setupTargets

Fixes #253