### PR TITLE
fix: check for existence of toolbar before performing target setup

### DIFF
--- a/lib/providers/controllerAutoCompleteProvider.js
+++ b/lib/providers/controllerAutoCompleteProvider.js
@@ -172,34 +172,45 @@ const customAlloyCompletionRules = [
 	{
 		regExp: /\$\.([-a-zA-Z0-9-_]*)\.(add|remove)EventListener\(["']([-a-zA-Z0-9-_/]*)$/,
 		getCompletions(request) {
-			let completions;
-			let line = Utils.getLine(request);
-			let regResult = this.regExp.exec(line);
-			if (regResult) {
-				let idName = regResult[1];
-				let textBuffer = Utils.getTextBuffer(related.getTargetPath('xml'));
+			const completions = [];
+			const line = Utils.getLine(request);
+			const regResult = this.regExp.exec(line);
 
-				if (!textBuffer.isEmpty()) {
-					completions = [];
-					let curTagName = '';
-					textBuffer.scan(new RegExp(`id=["']${idName}["']`, 'g'), function (item) {
-						curTagName = viewAutoCompleteProvider.getPreviousTag(textBuffer, item.range.start);
-						return item.stop();
-					});
+			if (!regResult) {
+				return;
+			}
 
-					if (curTagName && alloy.tags[curTagName]) {
-						let { apiName } = alloy.tags[curTagName];
-						let curTagObject = titanium.types[apiName];
-						for (const event of curTagObject.events) {
-							completions.push(autoCompleteHelper.suggestion({
-								type: 'event',
-								text: event,
-								api: apiName,
-								property: event
-							}));
-						}
-					}
-				}
+			const idName = regResult[1];
+			const textBuffer = Utils.getTextBuffer(related.getTargetPath('xml'));
+
+			if (textBuffer.isEmpty()) {
+				return;
+			}
+
+			let curTagName = '';
+			textBuffer.scan(new RegExp(`id=["']${idName}["']`, 'g'), function (item) {
+				curTagName = viewAutoCompleteProvider.getPreviousTag(textBuffer, item.range.start);
+				return item.stop();
+			});
+
+			if (!curTagName || !alloy.tags[curTagName]) {
+				return;
+			}
+
+			let { apiName } = alloy.tags[curTagName];
+			let curTagObject = titanium.types[apiName];
+
+			if (!curTagObject || !curTagObject.events) {
+				return;
+			}
+
+			for (const event of curTagObject.events) {
+				completions.push(autoCompleteHelper.suggestion({
+					type: 'event',
+					text: event,
+					api: apiName,
+					property: event
+				}));
 			}
 
 			return completions;


### PR DESCRIPTION
It's possible the toolbar has been uploaded between calling getInfo and setupTargets

Fixes #253