### PR TITLE
feat: support storing the last selected target for an app project

### DIFF
--- a/lib/ui/toolbar.jsx
+++ b/lib/ui/toolbar.jsx
@@ -54,7 +54,7 @@ export default class Toolbar {
 		}
 
 		// The defaults per platform
-		if (platform() === 'darvin') {
+		if (platform() === 'darwin') {
 			return {
 				value: 'ios',
 				text: 'iOS'


### PR DESCRIPTION
This is an attempt to store the last used target info for a project and then use that when we recreate the toolbar the next time a user opens the app. If the selected target no longer exists then we take the first emulator/simulator (this could probably be improved)